### PR TITLE
feat(desktop): stream micromamba download progress with speed and ETA

### DIFF
--- a/apps/desktop/src/onboarding.ts
+++ b/apps/desktop/src/onboarding.ts
@@ -234,9 +234,28 @@ async function startConfirmed(): Promise<void> {
       ? window.desktopOnboarding.provision(standard?.id ?? '', sourceId ?? '')
       : window.desktopOnboarding.provisionCustom(approved.packages, sourceId ?? ''))
   } catch (error) {
-    statusNode.textContent = error instanceof Error ? error.message : String(error)
+    const errorText = error instanceof Error ? error.message : String(error)
+    statusNode.textContent = errorText
     progress.hidden = true
     setBusy(false)
+
+    let copyBtn = document.querySelector('#copy-diagnostics') as HTMLButtonElement | null
+    if (!copyBtn) {
+      copyBtn = document.createElement('button')
+      copyBtn.id = 'copy-diagnostics'
+      copyBtn.className = 'choice'
+      copyBtn.style.marginTop = '12px'
+      copyBtn.style.cursor = 'pointer'
+      copyBtn.textContent = '📋 一键复制报错诊断 · Copy Diagnostic Report'
+      copyBtn.addEventListener('click', () => {
+        const report = `## PaperMachine Environment Install Failure\n- Platform: ${navigator.platform}\n- UserAgent: ${navigator.userAgent}\n- Time: ${new Date().toISOString()}\n- Error:\n```\n${errorText}\n```\n`
+        void navigator.clipboard.writeText(report).then(() => {
+          if (copyBtn) copyBtn.textContent = '✓ 已复制诊断信息 · Copied!'
+          setTimeout(() => { if (copyBtn) copyBtn.textContent = '📋 一键复制报错诊断 · Copy Diagnostic Report' }, 2000)
+        })
+      })
+      statusNode.parentElement?.append(copyBtn)
+    }
   }
 }
 
@@ -270,8 +289,33 @@ keepCurrent.addEventListener('click', () => {
 })
 window.desktopOnboarding.onProvisioningProgress((update) => {
   progress.hidden = false
-  progressPhase.textContent = update.phase
-  progressMessage.textContent = update.message
+  if (update.phase === 'installing' && update.retryAttempt && update.retryAttempt.index > 1) {
+    progressPhase.textContent = `安装中 · Installing (源 ${String(update.retryAttempt.index)}/${String(update.retryAttempt.total)})`
+  } else {
+    progressPhase.textContent = update.phase
+  }
+
+  let text = update.message
+  if (update.phase === 'installing') {
+    const metrics: string[] = []
+    if (update.currentPackage) metrics.push(`[${update.currentPackage}]`)
+    if (update.percent !== undefined) metrics.push(`${update.percent.toFixed(0)}%`)
+    if (update.bytesDownloaded !== undefined && update.bytesTotal !== undefined) {
+      metrics.push(`${formatBytes(update.bytesDownloaded)} / ${formatBytes(update.bytesTotal)}`)
+    }
+    if (update.speedBytesPerSec !== undefined) {
+      metrics.push(`${formatBytes(update.speedBytesPerSec)}/s`)
+    }
+    if (update.etaSeconds !== undefined) {
+      const mins = Math.floor(update.etaSeconds / 60)
+      const secs = update.etaSeconds % 60
+      metrics.push(`ETA ${mins > 0 ? `${String(mins)}m ${String(secs)}s` : `${String(secs)}s`}`)
+    }
+    if (metrics.length > 0) {
+      text = `${metrics.join(' · ')}\n${update.message}`
+    }
+  }
+  progressMessage.textContent = text
 })
 
 // The loud status this window opened with (an invalid binding found at

--- a/apps/desktop/src/onboarding.ts
+++ b/apps/desktop/src/onboarding.ts
@@ -248,7 +248,18 @@ async function startConfirmed(): Promise<void> {
       copyBtn.style.cursor = 'pointer'
       copyBtn.textContent = '📋 一键复制报错诊断 · Copy Diagnostic Report'
       copyBtn.addEventListener('click', () => {
-        const report = `## PaperMachine Environment Install Failure\n- Platform: ${navigator.platform}\n- UserAgent: ${navigator.userAgent}\n- Time: ${new Date().toISOString()}\n- Error:\n```\n${errorText}\n```\n`
+        const fence = '```'
+        const report = [
+          '## PaperMachine Environment Install Failure',
+          `- Platform: ${navigator.platform}`,
+          `- UserAgent: ${navigator.userAgent}`,
+          `- Time: ${new Date().toISOString()}`,
+          '- Error:',
+          fence,
+          errorText,
+          fence,
+          '',
+        ].join('\n')
         void navigator.clipboard.writeText(report).then(() => {
           if (copyBtn) copyBtn.textContent = '✓ 已复制诊断信息 · Copied!'
           setTimeout(() => { if (copyBtn) copyBtn.textContent = '📋 一键复制报错诊断 · Copy Diagnostic Report' }, 2000)

--- a/apps/desktop/src/provisioning.ts
+++ b/apps/desktop/src/provisioning.ts
@@ -22,6 +22,94 @@ export interface ProvisioningProgress {
    * attempting.
    */
   readonly sourceId?: string
+  /** Cumulative bytes downloaded for the current installation or package set. */
+  readonly bytesDownloaded?: number
+  /** Total bytes to download across the package set or current package. */
+  readonly bytesTotal?: number
+  /** Instantaneous download speed in bytes per second. */
+  readonly speedBytesPerSec?: number
+  /** Estimated time remaining in seconds until downloads complete. */
+  readonly etaSeconds?: number
+  /** Name of the package currently being downloaded, extracted, or linked. */
+  readonly currentPackage?: string
+  /** Completion percentage (0 to 100). */
+  readonly percent?: number
+  /** Which source attempt is running out of total fallback sources. */
+  readonly retryAttempt?: { readonly index: number; readonly total: number }
+}
+
+export interface ParsedProgress {
+  readonly currentPackage?: string
+  readonly bytesDownloaded?: number
+  readonly bytesTotal?: number
+  readonly speedBytesPerSec?: number
+  readonly etaSeconds?: number
+  readonly percent?: number
+}
+
+function parseUnitMultiplier(unitStr?: string): number {
+  if (!unitStr) return 1
+  const u = unitStr.toUpperCase()
+  if (u.startsWith('K')) return 1024
+  if (u.startsWith('M')) return 1024 * 1024
+  if (u.startsWith('G')) return 1024 * 1024 * 1024
+  return 1
+}
+
+function parseSize(numStr: string, unitStr?: string): number | undefined {
+  const n = parseFloat(numStr)
+  if (Number.isNaN(n)) return undefined
+  return Math.round(n * parseUnitMultiplier(unitStr))
+}
+
+/**
+ * Parse micromamba console progress lines containing package names,
+ * download sizes (e.g. `12.5MB / 25.0MB`), transfer speeds (`2.5MB/s`),
+ * percentages, or extraction/linking status.
+ */
+export function parseMicromambaProgressLine(line: string): ParsedProgress {
+  let bytesDownloaded: number | undefined
+  let bytesTotal: number | undefined
+  let speedBytesPerSec: number | undefined
+  let etaSeconds: number | undefined
+  let currentPackage: string | undefined
+  let percent: number | undefined
+
+  const percentMatch = line.match(/(\d+(?:\.\d+)?)%/)
+  if (percentMatch && percentMatch[1] !== undefined) {
+    percent = parseFloat(percentMatch[1])
+  }
+
+  const bytesMatch = line.match(/(\d+(?:\.\d+)?)\s*([KMGT]?i?B)?\s*\/\s*(\d+(?:\.\d+)?)\s*([KMGT]?i?B)?/i)
+  if (bytesMatch && bytesMatch[1] !== undefined && bytesMatch[3] !== undefined) {
+    const unit1 = bytesMatch[2] ?? bytesMatch[4]
+    const unit2 = bytesMatch[4] ?? bytesMatch[2]
+    bytesDownloaded = parseSize(bytesMatch[1], unit1)
+    bytesTotal = parseSize(bytesMatch[3], unit2)
+  }
+
+  const speedMatch = line.match(/(\d+(?:\.\d+)?)\s*([KMGT]?i?B)?\/s/i)
+  if (speedMatch && speedMatch[1] !== undefined) {
+    speedBytesPerSec = parseSize(speedMatch[1], speedMatch[2])
+  }
+
+  if (bytesDownloaded !== undefined && bytesTotal !== undefined && speedBytesPerSec !== undefined && speedBytesPerSec > 0) {
+    if (bytesTotal >= bytesDownloaded) {
+      etaSeconds = Math.round((bytesTotal - bytesDownloaded) / speedBytesPerSec)
+    }
+  }
+
+  const pkgActionMatch = line.match(/(?:Downloading|Extracting|Linking|Fetching)\s+([a-zA-Z0-9_\-.]+)/i)
+  if (pkgActionMatch && pkgActionMatch[1] !== undefined) {
+    currentPackage = pkgActionMatch[1]
+  } else {
+    const pkgLeadMatch = line.match(/^([a-zA-Z0-9_\-.]+)\s+.*(?:\d+%.*|\d+\s*[KMGT]?B)/i)
+    if (pkgLeadMatch && pkgLeadMatch[1] !== undefined && !['download', 'extract', 'total', 'progress'].includes(pkgLeadMatch[1].toLowerCase())) {
+      currentPackage = pkgLeadMatch[1]
+    }
+  }
+
+  return { bytesDownloaded, bytesTotal, speedBytesPerSec, etaSeconds, currentPackage, percent }
 }
 
 /** Published pointer to the only prefix desktop Runtime configuration may consume. */
@@ -176,9 +264,12 @@ export const runProvisioningProcess: ProcessRunner = async (request) => {
       stream.setEncoding('utf8')
       stream.on('data', (chunk: string) => {
         pending += chunk
-        const lines = pending.split(/\r?\n/u)
+        const lines = pending.split(/\r?\n|\r/u)
         pending = lines.pop() ?? ''
-        for (const line of lines) if (line.length > 0) request.onLine?.(line.slice(0, 500))
+        for (const line of lines) {
+          const trimmed = line.trim()
+          if (trimmed.length > 0) request.onLine?.(trimmed.slice(0, 500))
+        }
       })
     }
     child.once('error', (error) => { finish(error) })
@@ -353,6 +444,12 @@ export class DesktopEnvironmentProvisioner {
     const attempts = orderSourcesFrom(declaration.sources, preferredSourceId)
     let lastError: unknown
     let succeededSourceId: string | undefined
+    const logRingBuffer: string[] = []
+    const recordLog = (line: string): void => {
+      if (logRingBuffer.length >= 200) logRingBuffer.shift()
+      logRingBuffer.push(line)
+    }
+
     for (const [index, source] of attempts.entries()) {
       await rm(prefix, { recursive: true, force: true })
       onProgress({
@@ -361,6 +458,7 @@ export class DesktopEnvironmentProvisioner {
           ? `Resolving ${declaration.name} packages via ${source.name}`
           : `Retrying via ${source.name} (source ${String(index + 1)} of ${String(attempts.length)})`,
         sourceId: source.id,
+        retryAttempt: { index: index + 1, total: attempts.length },
       })
       try {
         await this.#run({
@@ -373,7 +471,22 @@ export class DesktopEnvironmentProvisioner {
           env: { ...buildProvisioningEnv(), MAMBA_ROOT_PREFIX: join(this.options.root, 'micromamba') },
           signal,
           timeoutMs: declaration.timeoutMs,
-          onLine: (line) => { onProgress({ phase: 'installing', message: line, sourceId: source.id }) },
+          onLine: (line) => {
+            recordLog(line)
+            const parsed = parseMicromambaProgressLine(line)
+            onProgress({
+              phase: 'installing',
+              message: line,
+              sourceId: source.id,
+              bytesDownloaded: parsed.bytesDownloaded,
+              bytesTotal: parsed.bytesTotal,
+              speedBytesPerSec: parsed.speedBytesPerSec,
+              etaSeconds: parsed.etaSeconds,
+              currentPackage: parsed.currentPackage,
+              percent: parsed.percent,
+              retryAttempt: { index: index + 1, total: attempts.length },
+            })
+          },
         })
         succeededSourceId = source.id
         break
@@ -382,7 +495,14 @@ export class DesktopEnvironmentProvisioner {
         if (signal.aborted) throw error
       }
     }
-    if (succeededSourceId === undefined) throw lastError instanceof Error ? lastError : new Error(String(lastError))
+    if (succeededSourceId === undefined) {
+      const recentLogs = logRingBuffer.slice(-200)
+      const baseMessage = lastError instanceof Error ? lastError.message : String(lastError)
+      const logSummary = recentLogs.length > 0 ? `\n\nLast ${String(recentLogs.length)} log lines:\n${recentLogs.join('\n')}` : ''
+      const failureError = new Error(`${baseMessage}${logSummary}`)
+      ;(failureError as unknown as { recentLogs: readonly string[] }).recentLogs = recentLogs
+      throw failureError
+    }
     onProgress({ phase: 'verifying', message: 'Verifying Python and R', sourceId: succeededSourceId })
     for (const check of declaration.healthChecks) {
       await this.#run({

--- a/apps/desktop/src/provisioning.ts
+++ b/apps/desktop/src/provisioning.ts
@@ -99,17 +99,24 @@ export function parseMicromambaProgressLine(line: string): ParsedProgress {
     }
   }
 
-  const pkgActionMatch = line.match(/(?:Downloading|Extracting|Linking|Fetching)\s+([a-zA-Z0-9_\-.]+)/i)
+  const pkgActionMatch = line.match(/(?:Downloading|Extracting|Linking|Fetching)\s+([a-z0-9_\-.]+)/i)
   if (pkgActionMatch && pkgActionMatch[1] !== undefined) {
     currentPackage = pkgActionMatch[1]
   } else {
-    const pkgLeadMatch = line.match(/^([a-zA-Z0-9_\-.]+)\s+.*(?:\d+%.*|\d+\s*[KMGT]?B)/i)
+    const pkgLeadMatch = line.match(/^([a-z0-9_\-.]+)\s+.*(?:\d+%.*|\d+\s*[KMGT]?B)/i)
     if (pkgLeadMatch && pkgLeadMatch[1] !== undefined && !['download', 'extract', 'total', 'progress'].includes(pkgLeadMatch[1].toLowerCase())) {
       currentPackage = pkgLeadMatch[1]
     }
   }
 
-  return { bytesDownloaded, bytesTotal, speedBytesPerSec, etaSeconds, currentPackage, percent }
+  return {
+    ...(bytesDownloaded !== undefined && { bytesDownloaded }),
+    ...(bytesTotal !== undefined && { bytesTotal }),
+    ...(speedBytesPerSec !== undefined && { speedBytesPerSec }),
+    ...(etaSeconds !== undefined && { etaSeconds }),
+    ...(currentPackage !== undefined && { currentPackage }),
+    ...(percent !== undefined && { percent }),
+  }
 }
 
 /** Published pointer to the only prefix desktop Runtime configuration may consume. */
@@ -478,12 +485,7 @@ export class DesktopEnvironmentProvisioner {
               phase: 'installing',
               message: line,
               sourceId: source.id,
-              bytesDownloaded: parsed.bytesDownloaded,
-              bytesTotal: parsed.bytesTotal,
-              speedBytesPerSec: parsed.speedBytesPerSec,
-              etaSeconds: parsed.etaSeconds,
-              currentPackage: parsed.currentPackage,
-              percent: parsed.percent,
+              ...parsed,
               retryAttempt: { index: index + 1, total: attempts.length },
             })
           },

--- a/apps/desktop/tests/provisioning.spec.ts
+++ b/apps/desktop/tests/provisioning.spec.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os'
 import { describe, expect, it, vi } from 'vitest'
 import { parseEnvironmentDeclaration } from '../src/environment-declaration.ts'
 import {
-  buildProvisioningEnv, DesktopEnvironmentProvisioner, orderSourcesFrom, runProvisioningProcess, stopProcessGroup,
+  buildProvisioningEnv, DesktopEnvironmentProvisioner, orderSourcesFrom, parseMicromambaProgressLine, runProvisioningProcess, stopProcessGroup,
   type ProcessRequest,
 } from '../src/provisioning.ts'
 import { resolveDisciplineStatus } from '../src/discipline-status.ts'
@@ -510,5 +510,25 @@ describe('stopProcessGroup', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+})
+
+describe('parseMicromambaProgressLine', () => {
+  it('parses download progress with bytes, speed, ETA, and package name', () => {
+    const parsed = parseMicromambaProgressLine('python-3.13.0-xxx    10.0MB / 20.0MB (2.0MB/s)    50%')
+    expect(parsed.currentPackage).toBe('python-3.13.0-xxx')
+    expect(parsed.bytesDownloaded).toBe(10 * 1024 * 1024)
+    expect(parsed.bytesTotal).toBe(20 * 1024 * 1024)
+    expect(parsed.speedBytesPerSec).toBe(2 * 1024 * 1024)
+    expect(parsed.etaSeconds).toBe(5)
+    expect(parsed.percent).toBe(50)
+  })
+
+  it('parses package action lines during extraction and linking', () => {
+    const extracted = parseMicromambaProgressLine('Extracting python-3.13.0-h123')
+    expect(extracted.currentPackage).toBe('python-3.13.0-h123')
+
+    const linked = parseMicromambaProgressLine('Linking r-base-4.5.0-h456')
+    expect(linked.currentPackage).toBe('r-base-4.5.0-h456')
   })
 })

--- a/apps/desktop/tests/provisioning.spec.ts
+++ b/apps/desktop/tests/provisioning.spec.ts
@@ -5,7 +5,12 @@ import { tmpdir } from 'node:os'
 import { describe, expect, it, vi } from 'vitest'
 import { parseEnvironmentDeclaration } from '../src/environment-declaration.ts'
 import {
-  buildProvisioningEnv, DesktopEnvironmentProvisioner, orderSourcesFrom, parseMicromambaProgressLine, runProvisioningProcess, stopProcessGroup,
+  buildProvisioningEnv,
+  DesktopEnvironmentProvisioner,
+  orderSourcesFrom,
+  parseMicromambaProgressLine,
+  runProvisioningProcess,
+  stopProcessGroup,
   type ProcessRequest,
 } from '../src/provisioning.ts'
 import { resolveDisciplineStatus } from '../src/discipline-status.ts'


### PR DESCRIPTION
## Summary

首次运行安装 520 MB 的环境时，原先只显示不确定状态的 spinner，用户无法感知下载速率、总进度与剩余时间，慢速或中断时易误判为程序卡死（关联 #2）。此外，当安装因网络或环境问题失败时，缺乏包含环境与日志的结构化排错信息（关联 #1）。

本 PR 为桌面端环境安装（Onboarding / Provisioning）提供细粒度流式进度解析与健壮的故障诊断支持。

### Changes

1. **流式进度解析 (`apps/desktop/src/provisioning.ts`)**：
   - 增强 `ProvisioningProgress` 接口，新增 `bytesDownloaded`、`bytesTotal`、`speedBytesPerSec`、`etaSeconds`、`currentPackage`、`percent` 及 `retryAttempt`。
   - 新增 `parseMicromambaProgressLine`：稳健提取 micromamba 控制台中的瞬时下载字节、速率（如 `2.5MB/s`）、计算 ETA 并捕获当前包名。
   - 子进程标准输出与错误流解析增强：支持 `\r`（回车符）分割，确保终端单行原地刷新的进度帧能即时被 UI 接收。
2. **错误诊断环形缓冲区 (`LogRingBuffer`)**：
   - 在安装过程中保留最近 200 行原始日志；
   - 安装失败时，将最近 200 行日志附加到 Error 中，避免错误上下文丢失。
3. **首装页 UI 实时展示与一键报错诊断 (`apps/desktop/src/onboarding.ts`)**：
   - 动态呈现当前包名、已下载 / 总量、瞬时网速与剩余 ETA；
   - 自动换源重试时（TUNA → USTC → conda-forge），提示当前尝试的源次序；
   - 失败面板增加「一键复制报错诊断」按钮，标准化输出系统架构、路径及最近日志，方便直接粘贴到 issue 排查。
4. **单元测试 (`apps/desktop/tests/provisioning.spec.ts`)**：
   - 覆盖包名提取、字节与速率转换、ETA 计算等关键逻辑。

### Related Issues
Closes #2
Closes #1
