### PR TITLE
feat(home-paths): configurable PAPERMACHINE_HOME and custom install directory

### DIFF
--- a/apps/desktop/src/harness-home.ts
+++ b/apps/desktop/src/harness-home.ts
@@ -25,11 +25,15 @@ function requireNoAsciiSpace(path: string): void {
 }
 
 /**
- * Resolve and create the Harness home directory used for `DSH_HOME`: a
- * fixed `.papermachine` subdirectory of the OS user home, deliberately
- * independent of Electron's own `userData` directory (which stays
- * Electron-owned, holding only its cookies, caches, and similar Electron
- * state — untouched by this resolution).
+ * Resolve and create the Harness home directory used for `DSH_HOME`,
+ * deliberately independent of Electron's own `userData` directory (which
+ * stays Electron-owned, holding only its cookies, caches, and similar
+ * Electron state — untouched by this resolution).
+ *
+ * Precedence: `customHomeDir` (an explicit choice, for example from
+ * onboarding directory selection or settings) over `process.env.PAPERMACHINE_HOME`,
+ * over `process.env.DSH_HOME`, over the fixed default `<osHomeDir>/.papermachine`
+ * when none of those is set.
  *
  * The science-runtime R probe and kernel both refuse to run with an ASCII
  * space anywhere in their scratch `TMPDIR`
@@ -37,35 +41,27 @@ function requireNoAsciiSpace(path: string): void {
  * `kernel-process.ts:340`), and on macOS Electron's `userData` path
  * (`~/Library/Application Support/<app name>`) contains one, which made
  * every R kernel fail unconditionally on desktop. Resolving under the home
- * directory directly avoids that path segment; the OS user home itself can
- * still contain a space, which the checks below catch.
+ * directory directly avoids that path segment; `osHomeDir`, `customHomeDir`,
+ * and both environment variables can still name a path that contains a
+ * space, which the checks below catch.
  *
- * The literal joined path is checked before creating anything, so an
- * obviously space-containing OS home fails without any filesystem side
+ * The literal candidate path is checked before creating anything, so an
+ * obviously space-containing candidate fails without any filesystem side
  * effect. Science Runtime itself derives every kernel and probe scratch
  * path from the canonical, `realpath`-resolved Harness home
  * (`scratch.ts`'s `rootForSession`), so a space-free literal path is not
- * sufficient by itself: an OS home that is, or sits under, a symlink whose
+ * sufficient by itself: a candidate that is, or sits under, a symlink whose
  * real target contains a space would pass the literal check and only fail
  * later, inside a kernel process. The directory is therefore also
  * canonicalized and re-checked after creation, and the canonical path —
  * not the literal one — is what `DSH_HOME` is set to.
- * @param osHomeDir - the OS user home directory (Electron's `app.getPath('home')`).
+ * @param osHomeDir - the OS user home directory (Electron's `app.getPath('home')`), used only when
+ *   neither `customHomeDir` nor either environment variable is set.
+ * @param customHomeDir - an explicit Harness home directory, taking precedence over both
+ *   `PAPERMACHINE_HOME` and `DSH_HOME`.
  * @returns the absolute, canonical, already-created Harness home path.
  * @throws {@link HarnessHomeSpaceError} when the literal or canonical
  *   resolved path contains an ASCII space.
- */
-/**
- * Resolve and create the Harness home directory used for `DSH_HOME`.
- *
- * Precedence:
- * 1. `customHomeDir` passed explicitly (e.g. from onboarding directory selection or settings)
- * 2. `process.env.PAPERMACHINE_HOME`
- * 3. `process.env.DSH_HOME`
- * 4. Default: `<osHomeDir>/.papermachine`
- *
- * Checks that neither the literal path nor its canonical realpath contains
- * an ASCII space (preserving R TMPDIR safety across all platforms).
  */
 export async function resolveHarnessHome(osHomeDir: string, customHomeDir?: string): Promise<string> {
   const envHome = process.env.PAPERMACHINE_HOME ?? process.env.DSH_HOME

--- a/apps/desktop/src/harness-home.ts
+++ b/apps/desktop/src/harness-home.ts
@@ -55,11 +55,26 @@ function requireNoAsciiSpace(path: string): void {
  * @throws {@link HarnessHomeSpaceError} when the literal or canonical
  *   resolved path contains an ASCII space.
  */
-export async function resolveHarnessHome(osHomeDir: string): Promise<string> {
-  const dshHome = join(osHomeDir, '.papermachine')
-  requireNoAsciiSpace(dshHome)
-  await mkdir(dshHome, { recursive: true, mode: 0o700 })
-  const canonical = await realpath(dshHome)
+/**
+ * Resolve and create the Harness home directory used for `DSH_HOME`.
+ *
+ * Precedence:
+ * 1. `customHomeDir` passed explicitly (e.g. from onboarding directory selection or settings)
+ * 2. `process.env.PAPERMACHINE_HOME`
+ * 3. `process.env.DSH_HOME`
+ * 4. Default: `<osHomeDir>/.papermachine`
+ *
+ * Checks that neither the literal path nor its canonical realpath contains
+ * an ASCII space (preserving R TMPDIR safety across all platforms).
+ */
+export async function resolveHarnessHome(osHomeDir: string, customHomeDir?: string): Promise<string> {
+  const envHome = process.env.PAPERMACHINE_HOME ?? process.env.DSH_HOME
+  const candidate = customHomeDir !== undefined && customHomeDir.trim().length > 0
+    ? customHomeDir.trim()
+    : (envHome !== undefined && envHome.trim().length > 0 ? envHome.trim() : join(osHomeDir, '.papermachine'))
+  requireNoAsciiSpace(candidate)
+  await mkdir(candidate, { recursive: true, mode: 0o700 })
+  const canonical = await realpath(candidate)
   requireNoAsciiSpace(canonical)
   return canonical
 }

--- a/apps/desktop/tests/harness-home.spec.ts
+++ b/apps/desktop/tests/harness-home.spec.ts
@@ -59,4 +59,25 @@ describe('resolveHarnessHome', () => {
     expect(error).toBeInstanceOf(HarnessHomeSpaceError)
     expect((error as HarnessHomeSpaceError).path).toBe(join(realTarget, '.papermachine'))
   })
+
+  it('respects an explicit customHomeDir override when provided', async () => {
+    const home = await makeHome()
+    const custom = await makeHome()
+
+    const dshHome = await resolveHarnessHome(home, custom)
+
+    expect(dshHome).toBe(custom)
+  })
+
+  it('respects process.env.PAPERMACHINE_HOME when set', async () => {
+    const home = await makeHome()
+    const custom = await makeHome()
+    process.env.PAPERMACHINE_HOME = custom
+    try {
+      const dshHome = await resolveHarnessHome(home)
+      expect(dshHome).toBe(custom)
+    } finally {
+      delete process.env.PAPERMACHINE_HOME
+    }
+  })
 })

--- a/packages/util/home-paths/src/index.ts
+++ b/packages/util/home-paths/src/index.ts
@@ -17,6 +17,9 @@ export const DEFAULT_DSH_HOME_DISPLAY = `~/${DSH_HOME_DIR_NAME}`
 /** Environment variable that overrides the default DeepSeek Harness home. */
 export const DSH_HOME_ENV = 'DSH_HOME'
 
+/** Environment variable that configures the PaperMachine home directory. */
+export const PAPERMACHINE_HOME_ENV = 'PAPERMACHINE_HOME'
+
 /**
  * Give a native filesystem watcher one canonical spelling of a path, even
  * when its final components do not exist yet. The deepest existing ancestor
@@ -85,7 +88,7 @@ export function expandHomePath(path: string): string {
  * @returns the normalized absolute harness home path.
  */
 export function resolveDshHome(configured?: string, env: Record<string, string | undefined> = process.env): string {
-  const fromEnv = env[DSH_HOME_ENV]
+  const fromEnv = env[PAPERMACHINE_HOME_ENV] ?? env[DSH_HOME_ENV]
   const selected = configured ?? (fromEnv !== undefined && fromEnv.trim().length > 0 ? fromEnv : defaultDshHome())
   return resolve(expandHomePath(selected))
 }

--- a/packages/util/home-paths/tests/home-paths.spec.ts
+++ b/packages/util/home-paths/tests/home-paths.spec.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   DEFAULT_DSH_HOME_DISPLAY,
   DSH_HOME_DIR_NAME,
+  PAPERMACHINE_HOME_ENV,
   canonicalizeWatchPath,
   defaultDshHome,
   dshHomeDisplay,
@@ -72,5 +73,10 @@ describe('dsh path helpers', () => {
     } finally {
       await rm(root, { recursive: true, force: true })
     }
+  })
+
+  it('resolves PAPERMACHINE_HOME with precedence over DSH_HOME', () => {
+    const pmHome = join(homedir(), 'custom-pm-home')
+    expect(resolveDshHome(undefined, { PAPERMACHINE_HOME: '~/custom-pm-home', DSH_HOME: '~/dsh-home' })).toBe(pmHome)
   })
 })

--- a/packages/util/home-paths/tests/home-paths.spec.ts
+++ b/packages/util/home-paths/tests/home-paths.spec.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   DEFAULT_DSH_HOME_DISPLAY,
   DSH_HOME_DIR_NAME,
+  DSH_HOME_ENV,
   PAPERMACHINE_HOME_ENV,
   canonicalizeWatchPath,
   defaultDshHome,
@@ -77,6 +78,6 @@ describe('dsh path helpers', () => {
 
   it('resolves PAPERMACHINE_HOME with precedence over DSH_HOME', () => {
     const pmHome = join(homedir(), 'custom-pm-home')
-    expect(resolveDshHome(undefined, { PAPERMACHINE_HOME: '~/custom-pm-home', DSH_HOME: '~/dsh-home' })).toBe(pmHome)
+    expect(resolveDshHome(undefined, { [PAPERMACHINE_HOME_ENV]: '~/custom-pm-home', [DSH_HOME_ENV]: '~/dsh-home' })).toBe(pmHome)
   })
 })


### PR DESCRIPTION
## Summary

目前环境安装目录固定为 `<OS 用户主目录>/.papermachine`（硬编码在 `resolveHarnessHome` 中）。这在 Windows 场景下带来两大约束：
1. **C 盘空间紧张（关联 #3）**：通用科学环境需要 ~6 GB 磁盘空间，很多 Windows 用户的 C 盘仅为小型系统盘，数据和工具需安放到 D 盘或其他盘符；
2. **用户名含空格或长路径解压失败（关联 #4）**：若用户名含空格（如 `C:\Users\John Doe`），会触发 `HarnessHomeSpaceError` 拒绝启动；同时默认的深层嵌套目录在 Windows 限制（`MAX_PATH=260`）下，容易导致 Qt 6.11 等大型包在解压回滚时失败。

本 PR 为 PaperMachine 引入可配置的 `PAPERMACHINE_HOME` 支持与自定义安装目录解析能力。

### Changes

1. **新增 `PAPERMACHINE_HOME` 支持 (`packages/util/home-paths/src/index.ts`)**：
   - 导出 `PAPERMACHINE_HOME_ENV = 'PAPERMACHINE_HOME'`；
   - `resolveDshHome` 优先级重构：`configured > process.env.PAPERMACHINE_HOME > process.env.DSH_HOME > defaultDshHome()`；
   - 补充单元测试（`home-paths.spec.ts`）。
2. **桌面主目录解析解耦 (`apps/desktop/src/harness-home.ts`)**：
   - `resolveHarnessHome` 支持显式 `customHomeDir` 参数或读取 `PAPERMACHINE_HOME` / `DSH_HOME`；
   - 严格延续安全约束：输入路径和其规范化 `realpath` 均强制检查不含 ASCII 空格，确保 R 运行时的 scratch `TMPDIR` 安全不受破坏；
   - 补充单元测试（`harness-home.spec.ts`）。

### Related Issues
Closes #3
Closes #4
