### PR TITLE
fix(directory-picker-native): read the Win32 folder path by its exact length

### DIFF
--- a/packages/host/directory-picker-native/src/win32-dialog-bindings.ts
+++ b/packages/host/directory-picker-native/src/win32-dialog-bindings.ts
@@ -29,16 +29,24 @@ interface Koffi {
 }
 
 /**
- * Read a NUL-terminated UTF-16 string at a native address. koffi's
- * `_Out_ void **` out-params surface a raw address, and
+ * Read a UTF-16 string at a native address, sized by `lstrlenW` rather than
+ * a fixed view. `GetDisplayName`'s result is a `CoTaskMemAlloc`'d buffer
+ * exactly `(length + 1) * 2` bytes long — `length` UTF-16 code units plus
+ * the terminating NUL — so viewing more than that reads unallocated memory;
+ * when the allocation sits near the end of a committed page this faults the
+ * process instead of returning garbage
+ * (https://github.com/SuperJJ007/papermachine/issues/5). `lstrlenW` reports
+ * `length` excluding the NUL, so `(length + 1) * 2` covers exactly the
+ * allocation, terminator included; an empty string (`length === 0`) views
+ * the 2-byte NUL-only allocation and decodes to `''` with no special case.
+ * koffi's `_Out_ void **` out-params surface a raw address, and
  * `koffi.decode(addr, 'str16')` would dereference it as a pointer — crash
- * on real Windows — so view the memory directly instead.
+ * on real Windows — so view the exact-length memory directly instead.
  */
-function readUtf16(koffi: Koffi, address: unknown): string {
-  const bytes = Buffer.from(koffi.view(address, 32768))
-  let end = 0
-  while (end + 1 < bytes.length && bytes[end] !== 0) end += 2
-  return bytes.toString('utf16le', 0, end)
+function readUtf16(koffi: Koffi, lstrlenW: KoffiFunction, address: unknown): string {
+  const length = lstrlenW(address) as number
+  const bytes = Buffer.from(koffi.view(address, (length + 1) * 2))
+  return bytes.toString('utf16le', 0, length * 2)
 }
 
 const COINIT_APARTMENTTHREADED = 0x2
@@ -98,6 +106,7 @@ export async function loadWin32DialogBindings(): Promise<Win32DialogBindings> {
   const coUninitialize = ole32.func('__stdcall', 'CoUninitialize', 'void', [])
   const coCreateInstance = ole32.func('__stdcall', 'CoCreateInstance', 'int32', ['void *', 'void *', 'uint32', 'void *', 'void *'])
   const coTaskMemFree = ole32.func('__stdcall', 'CoTaskMemFree', 'void', ['void *'])
+  const lstrlenW = kernel32.func('__stdcall', 'lstrlenW', 'int', ['void *'])
   const getCurrentThreadId = kernel32.func('__stdcall', 'GetCurrentThreadId', 'uint32', [])
 
   const protoShow = koffi.proto('int32 __stdcall DshDialogShow(void *self, void *owner)')
@@ -156,7 +165,7 @@ export async function loadWin32DialogBindings(): Promise<Win32DialogBindings> {
             const nameOut: unknown[] = [null]
             const gotName = method(item, SLOT_GET_DISPLAY_NAME, protoGetDisplayName)(SIGDN_FILESYSPATH, nameOut)
             if (gotName < 0) return { hr: gotName }
-            const path = readUtf16(koffi, nameOut[0])
+            const path = readUtf16(koffi, lstrlenW, nameOut[0])
             coTaskMemFree(nameOut[0])
             return { hr: gotName, path }
           } finally {

--- a/packages/host/directory-picker-native/tests/win32-dialog-bindings.spec.ts
+++ b/packages/host/directory-picker-native/tests/win32-dialog-bindings.spec.ts
@@ -105,6 +105,7 @@ function installFakeKoffi(world: ComWorld): void {
               return 0
             }
             case 'CoTaskMemFree': return (ptr: unknown) => { world.freed.push(ptr) }
+            case 'lstrlenW': return (ptr: unknown) => ((ptr as FakePtr).text as string).length
             case 'GetCurrentThreadId': return () => 31337
             case 'SetThreadDpiAwarenessContext': {
               if (!world.hasThreadDpi) throw new Error(`${dll}: SetThreadDpiAwarenessContext not found`)
@@ -128,8 +129,16 @@ function installFakeKoffi(world: ComWorld): void {
       pointer: (type: unknown) => type,
       sizeof: (type: string) => { void type; return FAKE_POINTER_SIZE },
       view: (value: unknown, len: number): ArrayBuffer => {
+        // Models the real CoTaskMemAlloc'd buffer: exactly (text.length + 1)
+        // UTF-16 code units (the terminating NUL included). A view past that
+        // reads unallocated memory — a real page-boundary fault when the
+        // allocation sits at the end of a committed page — so the fake
+        // throws instead of silently returning it.
+        const text = (value as FakePtr).text as string
+        const allocatedBytes = (text.length + 1) * 2
+        if (len > allocatedBytes) throw new Error(`view(${len}) exceeds the ${allocatedBytes}-byte allocation`)
         const bytes = Buffer.alloc(len)
-        bytes.write((value as FakePtr).text as string, 'utf16le')
+        bytes.write(text, 'utf16le')
         return bytes.buffer
       },
       register: (fn: (hwnd: unknown, lparam: unknown) => number) => { world.registered += 1; return { fn } },
@@ -178,6 +187,18 @@ describe('loadWin32DialogBindings over the fake COM world', () => {
     expect(world.freed).toHaveLength(1)
     expect(world.released).toEqual(['item', 'dialog'])
     expect(world.uninitialized).toBe(1)
+  })
+
+  it.each([
+    ['an ASCII path', 'C:\\Users\\alex\\Documents'],
+    ['a path with spaces and CJK characters', 'D:\\研究 数据\\项目'],
+    ['an empty path', ''],
+  ])('reads %s by its exact lstrlenW length, not a fixed-size view', async (_label, path) => {
+    const world = comWorld({ path })
+    installFakeKoffi(world)
+    const { loadWin32DialogBindings } = await loadBindingsModule()
+    const bindings = await loadWin32DialogBindings()
+    expect(runFolderDialog(bindings, 'Pick', vi.fn())).toBe(path)
   })
 
   it('maps dismissal and the S_FALSE CoInitializeEx', async () => {


### PR DESCRIPTION
## Summary

Windows 原生目录选择器在选中目录后 worker 崩溃（#5）。`readUtf16` 对 `IShellItem::GetDisplayName` 返回的 `PWSTR` 固定 `koffi.view(address, 32768)`，而该缓冲区只有 `(length + 1) * 2` 字节；越过页边界读取时进程直接 fault，含空格与中文的路径更容易触发。

### Changes

- 绑定 kernel32 的 `lstrlenW`，先取长度，再按 `(length + 1) * 2` 字节精确 view 并按 `length * 2` 字节解码 utf16le；空串无需特判。
- 测试中的假 koffi 在 `view` 长度超出模拟分配时抛错，复现页错误形态；新增 ASCII、`D:\研究 数据\项目`、空串三组用例。修复前这些用例连同 3 个既有用例一起失败，修复后全绿；`win32-dialog-bindings.ts` 覆盖率保持 100%。

### 需要实机验证

本机无法运行 Win32 对话框，真实 Windows 上的选目录流程仍需确认。@TyrionH-is-coding 如方便请帮忙在原来复现的路径上再试一次。

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fcs8fowpyExwnrD3j3qSuz
