### PR TITLE
feat(desktop): biology discipline environment + six biology skills

### DIFF
--- a/.agents/notes/proposed/feature/2026-10-05-biology-discipline-environment-and-skills.md
+++ b/.agents/notes/proposed/feature/2026-10-05-biology-discipline-environment-and-skills.md
@@ -1,0 +1,53 @@
+# Biology discipline: environment declaration and six domain skills
+
+- **Status:** proposed
+- **Scope:** `apps/desktop/resources/environments/biology.json`, `apps/desktop/src/main.ts`, `apps/desktop/src/telemetry.ts` (type widening), `apps/desktop/resources/onboarding.html` / `src/onboarding.ts` (discipline picker), `apps/desktop/resources/skills/{bulk-rnaseq-analysis,single-cell-analysis,sequence-analysis,survival-analysis,bioassay-and-dose-response,ecology-and-diversity}/`, `apps/desktop/resources/skills/SOURCES.md`, `README.md` (What is inside / Roadmap)
+- **Related:** [desktop owns its environment](../../implemented/feature/2026-09-01-desktop-owns-its-environment.md), [science desktop product](../../proposed/architecture/2026-08-23-science-desktop-product.md), README Roadmap item "Discipline environments"
+
+## Problem
+
+PaperMachine ships one environment (`general`) and three discipline-neutral skills. A biologist opening the app hits three walls in the first session: the shipped stack has no sequence, single-cell, survival, or community-ecology library, so the model's first `run_python` fails on `import scanpy`; the three bundled skills give no domain workflow, so the model improvises RNA-seq QC or a PERMANOVA from memory and skips the checks a reviewer looks for (low-count filtering rule, dispersion test beside PERMANOVA, risk table under a KM curve); and the Host overlay's `installChannels` come only from `general`'s conda-forge sources, so `install_science_packages` cannot reach bioconda even when the user asks for DESeq2 by name.
+
+The README Roadmap already names discipline environments as the next step. This note proposes biology as the first one, because the shipped tool surface (Python + R kernels, PNG capture via matplotlib/ggplot2, CSV auto-capture) already matches how computational biology is done and because the discipline's two platforms of choice (macOS, Windows) are exactly the ones the desktop ships.
+
+## Design
+
+### Environment declaration
+
+`biology.json` is a **superset of `general`** (a prefix binds both interpreters, so a user who switches disciplines loses nothing), adding on the Python side `biopython`, `scanpy`, `anndata`, `leidenalg`, `python-igraph`, `umap-learn`, `lifelines`, `scikit-posthocs`, and on the R side `survival`, `survminer`, `vegan`, `ape`, `phangorn`, `pheatmap`, `ggpubr`, `rstatix`, `emmeans`, `drc`. Every added package resolves from **conda-forge alone** on all three shipped platforms, so `supportedPlatforms` stays complete and the three-source fallback keeps the same success probability as `general`.
+
+Each source lists **two channels**: the conda-forge mirror and the bioconda mirror of the same provider (TUNA and USTC both mirror bioconda). Provisioning does not need bioconda for the declared set — the second channel exists so that the overlay's `installChannels`, once derived from the applied declaration rather than from `general`, let `install_science_packages r bioconductor-deseq2` succeed on macOS. Bioconductor packages are deliberately **not** in the declaration: bioconda publishes no `win-64` builds, so declaring them would remove Windows from `supportedPlatforms`; and DESeq2/clusterProfiler pull `org.*.eg.db` annotation trees that would roughly double the download. The skills install them on demand and name `pydeseq2`/`gseapy` (bioconda `noarch`, installable on Windows) as the equivalent path.
+
+Sizing: ~780 MB download, 8 GB free (`general` is 520 MB / 6 GB). The revision is `2026.10.1`. Version pins follow `general`'s `name=major.minor` style; the `TOKEN` grammar admits `=` but not `>=`, so no range pins.
+
+### `main.ts`
+
+`SHIPPED_ENVIRONMENT_ID` becomes the ordered list `SHIPPED_ENVIRONMENT_IDS = ['general', 'biology']`. `declarations()` returns every shipped declaration plus the custom one; the custom editor still seeds from `general`. `writeRuntimeOverlay` resolves the **applied** declaration through `provisioner(dshHome).applied()` and uses its sources for `installChannels`, falling back to `general`'s when no applied declaration resolves (a binding from a build before this change). `environment.installed` telemetry reports the shipped discipline id — a closed build-time vocabulary — and `'custom'` as before; the `TelemetryEvent` type widens from `'general' | 'custom'` to the shipped id union plus `'custom'`.
+
+The onboarding renderer already receives an array from `desktop:environments`; it gains a radio list rendered from that array (name, package count, download size) with `general` preselected, and passes the chosen id to `desktop:provision`. "View the full package list" and the advanced editor read from the selected declaration. `resolveDisciplineStatus` needs no change: it already matches by id and revision across the list.
+
+### Skills
+
+Six skills, each a `SKILL.md` plus first-party `scripts/` and `references/`, written to the same frontmatter and body discipline as the vendored three (Chinese trigger terms in `description`, an Installation table that routes through `install_science_packages`, a numbered workflow, integrity rules, a quick reference, and links into `references/`). Each body stays under ~1,400 words. Choice of the six follows what a biology user asks in a first week: bulk RNA-seq DE + enrichment; single-cell scanpy pipeline with pseudobulk DE; sequence handling and phylogenies; survival analysis; wet-lab assay fitting (IC50, growth curves, qPCR, standard curves); and community/microbiome diversity. Every skill degrades gracefully on the `general` environment (its Installation step installs what is missing) and states which packages are macOS-only.
+
+The skills are **not vendored** from `K-Dense-AI/scientific-agent-skills`: that repository's biology entries assume a shell, `Write`, and network access, and their bodies exceed the context budget the three vendored skills were rewritten to. Authoring against the Science tool set directly is smaller than rewriting, and keeps `scripts/` editable in-tree. `SOURCES.md` records this split.
+
+### What stays out
+
+- No new Cordis plugin or `ctx` service: the discipline surface is data (a declaration) plus skills, exactly the extension points the desktop already exposes. A biology-specific tool (e.g. a BLAST runner) would need a `ctx.subprocess`-backed capability and an approval policy; that is a separate note.
+- No default environment change: `general` remains preselected.
+- No bundled reference databases (gene sets, annotation DBs); skills fetch them through the package's own network path or ask for a local file.
+
+## Consequences
+
+- Windows users get every declared package and the Python DE/enrichment path; Bioconductor stays macOS-only and every skill says so up front.
+- The overlay now depends on `applied.json`; a missing pointer falls back to today's behaviour.
+- `resources/environments/` gains a second declaration the release workflow must ship; `verify` steps for declarations (schema parse) already run per file.
+- Nine bundled skills instead of three: the `/` catalog entry grows by six lines; skill bodies load only when invoked.
+
+## Verification
+
+1. `pnpm run typecheck` (main.ts, telemetry type).
+2. `apps/desktop` unit tests: declaration parser on `biology.json`; `declarations()` returns two shipped entries; overlay sources follow the applied declaration and fall back to `general`.
+3. On macOS arm64 and Windows x64: provision `biology` from each source; both health checks pass; `install_science_packages r bioconductor-deseq2` succeeds on macOS and fails cleanly on Windows with the Runtime's stdout showing no bioconda candidate.
+4. Invoke each skill via `/` on a small public dataset (airway counts, pbmc3k, a 16S ASV table, `lung` from R survival) and confirm the declared PNGs are captured and the CSV artifacts appear.

--- a/README.i18n.yaml
+++ b/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write README.md
-README.md: d7688fecb9a19f882d10a523d08fa11b87bdc3c0
-README.zh.md: 39c359f2d58a402db2661b70f7bebbe5df822a09
+README.md: 43ad8947c275426dc29026ec5eda95f549d5ea0e
+README.zh.md: 1999e7ccf534a0f8751d19a99b00ccbddfee117c

--- a/README.md
+++ b/README.md
@@ -86,9 +86,26 @@ On Windows, SmartScreen warns about an unrecognized publisher: choose **More inf
 </details>
 
 <details>
+<summary>The biology discipline environment (40 packages)</summary>
+
+Superset of the general science environment, adding computational biology and wet-lab assay analysis libraries.
+
+| Python 3.13 | R 4.5 |
+|---|---|
+| Biopython, scanpy, anndata | survival, survminer |
+| leidenalg, python-igraph, umap-learn | vegan, ape, phangorn |
+| lifelines, scikit-posthocs | pheatmap, ggpubr, rstatix, emmeans, drc |
+
+</details>
+
+<details>
 <summary>Skills and tools</summary>
 
-Three bundled skills, invoked by typing `/` in the composer: `scientific-visualization`, `statistical-analysis`, and `scientific-writing`. Your own skills in `~/.papermachine/skills` shadow bundled ones of the same name.
+Nine bundled skills, invoked by typing `/` in the composer:
+- Core science: `scientific-visualization`, `statistical-analysis`, `scientific-writing`
+- Biology: `bulk-rnaseq-analysis`, `single-cell-analysis`, `sequence-analysis`, `survival-analysis`, `bioassay-and-dose-response`, `ecology-and-diversity`
+
+Your own skills in `~/.papermachine/skills` shadow bundled ones of the same name.
 
 Five science tools the model can call: `run_python`, `run_r`, `get_science_state`, `annotate_artifact`, and `install_science_packages`. The model has read-only access to your workspace and no shell.
 
@@ -119,7 +136,7 @@ PaperMachine 0.1 is an early release. Known limitations:
 ## Roadmap
 
 - Windows analysis support: pipe-based kernel transport and explicit sandbox policy for the Windows backend.
-- Discipline environments, starting with the social sciences.
+- Discipline environments: biology environment and domain skills shipped; social sciences next.
 - A variable history view: shape changes of each dataset across cleaning steps.
 
 ## Feedback

--- a/README.zh.md
+++ b/README.zh.md
@@ -86,9 +86,26 @@ Windows 上 SmartScreen 会提示发布者无法识别:点**更多信息**,再�
 </details>
 
 <details>
+<summary>生物学学科环境（40 个包）</summary>
+
+通用科学环境的超集，增加计算生物学与湿实验分析库。
+
+| Python 3.13 | R 4.5 |
+|---|---|
+| Biopython、scanpy、anndata | survival、survminer |
+| leidenalg、python-igraph、umap-learn | vegan、ape、phangorn |
+| lifelines、scikit-posthocs | pheatmap、ggpubr、rstatix、emmeans、drc |
+
+</details>
+
+<details>
 <summary>技能与工具</summary>
 
-三个内置技能,在输入框键入 `/` 调用:`scientific-visualization`、`statistical-analysis`、`scientific-writing`。放在 `~/.papermachine/skills` 里的同名技能会覆盖内置的。
+内置九个技能，在输入框键入 `/` 调用：
+- 通用科学：`scientific-visualization`、`statistical-analysis`、`scientific-writing`
+- 生物学领域：`bulk-rnaseq-analysis`、`single-cell-analysis`、`sequence-analysis`、`survival-analysis`、`bioassay-and-dose-response`、`ecology-and-diversity`
+
+放在 `~/.papermachine/skills` 里的同名技能会覆盖内置的。
 
 模型可调用的五个科研工具:`run_python`、`run_r`、`get_science_state`、`annotate_artifact`、`install_science_packages`。模型对你的工作区只读,且没有 shell。
 
@@ -115,7 +132,7 @@ PaperMachine 0.1 是早期版本。已知限制:
 ## 路线图
 
 - Windows 分析运行支持：基于管道的内核传输与 Windows 后端显式沙箱等级策略。
-- 学科环境,从社会科学开始。
+- 学科环境：已内置生物学环境及领域技能；社会科学环境正在规划中。
 - 变量变化史视图:每个数据集在各清洗步骤中的形状变化。
 
 ## 反馈

--- a/apps/desktop/resources/environments/biology.json
+++ b/apps/desktop/resources/environments/biology.json
@@ -1,0 +1,58 @@
+{
+  "schemaVersion": 1,
+  "id": "biology",
+  "revision": "2026.10.1",
+  "name": "生物学环境 · Biology",
+  "supportedPlatforms": ["darwin-arm64", "darwin-x64", "win32-x64"],
+  "sources": [
+    {
+      "id": "tuna",
+      "name": "清华 TUNA 镜像 · TUNA mirror",
+      "channels": [
+        "https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/conda-forge",
+        "https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/bioconda"
+      ]
+    },
+    {
+      "id": "ustc",
+      "name": "中科大 USTC 镜像 · USTC mirror",
+      "channels": [
+        "https://mirrors.ustc.edu.cn/anaconda/cloud/conda-forge",
+        "https://mirrors.ustc.edu.cn/anaconda/cloud/bioconda"
+      ]
+    },
+    {
+      "id": "official",
+      "name": "官方源 · Official channels",
+      "channels": [
+        "https://conda.anaconda.org/conda-forge",
+        "https://conda.anaconda.org/bioconda"
+      ]
+    }
+  ],
+  "packages": [
+    "python=3.13", "numpy=2.3", "scipy=1.16", "pandas=2.3", "matplotlib=3.10", "seaborn=0.13",
+    "statsmodels=0.14", "scikit-learn=1.7", "pyarrow=21", "openpyxl=3.1", "pyreadstat=1.3", "pillow=11",
+    "biopython=1.85", "scanpy=1.11", "anndata=0.12", "leidenalg=0.10", "python-igraph=0.11",
+    "umap-learn=0.5", "lifelines=0.30", "scikit-posthocs=0.11",
+    "r-base=4.5", "r-tidyverse=2.0", "r-haven=2.5", "r-broom=1.0", "r-modelr=0.1", "r-lme4",
+    "r-survey=4.5", "r-srvyr=1.3", "r-data.table=1.18", "r-jsonlite=2.0",
+    "r-survival=3.8", "r-survminer=0.5", "r-vegan=2.6", "r-ape=5.8", "r-phangorn=2.12",
+    "r-pheatmap=1.0", "r-ggpubr=0.6", "r-rstatix=0.7", "r-emmeans=1.10", "r-drc=3.0"
+  ],
+  "estimatedDownloadBytes": 780000000,
+  "requiredFreeBytes": 8000000000,
+  "timeoutMs": 3600000,
+  "healthChecks": [
+    {
+      "language": "python",
+      "executable": "python",
+      "args": ["-c", "import numpy,scipy,pandas,matplotlib,seaborn,statsmodels,sklearn,pyarrow,openpyxl,pyreadstat,PIL,Bio,scanpy,anndata,leidenalg,igraph,umap,lifelines,scikit_posthocs"]
+    },
+    {
+      "language": "r",
+      "executable": "Rscript",
+      "args": ["-e", "library(tidyverse);library(haven);library(lme4);library(survey);library(data.table);library(survival);library(survminer);library(vegan);library(ape);library(phangorn);library(pheatmap);library(ggpubr);library(drc)"]
+    }
+  ]
+}

--- a/apps/desktop/resources/onboarding.html
+++ b/apps/desktop/resources/onboarding.html
@@ -23,7 +23,8 @@
   </section>
 
   <section id="install" class="group">
-    <h2>安装标准环境 · Install the standard environment</h2>
+    <h2>安装科学环境 · Install a science environment</h2>
+    <div id="offered-environments" class="choices" style="margin-bottom: 14px" hidden></div>
     <p id="install-summary">读取中… Loading…</p>
     <details>
       <summary>查看完整包清单 · View the full package list</summary>

--- a/apps/desktop/resources/skills/SOURCES.md
+++ b/apps/desktop/resources/skills/SOURCES.md
@@ -25,3 +25,33 @@ may change with the upstream content). Leave `references/`, `scripts/`, and
 `assets/` unmodified. Update the commit and copy date above. Do not hand-edit
 `references/`, `scripts/`, or `assets/` — a local fix belongs upstream, then flows
 back through the next re-copy.
+
+## Biology skills (authored in this repository)
+
+Six further directories — `bulk-rnaseq-analysis/`, `single-cell-analysis/`,
+`sequence-analysis/`, `survival-analysis/`, `bioassay-and-dose-response/`,
+`ecology-and-diversity/` — are **not** vendored. They were written for PaperMachine
+directly against the Science agent's tool set (`run_python`/`run_r`,
+`SCIENCE_ARTIFACT_DIR`, `raster_artifacts`, `install_science_packages`, read-only
+workspace, no shell) and against the shipped `biology` environment declaration
+(`resources/environments/biology.json`). Their `scripts/` and `references/` are
+first-party and may be edited in place; a fix does not need to flow through an
+upstream. Each `SKILL.md` frontmatter follows the same shape as the vendored
+three (`name`, `description` with Chinese trigger terms, `license`, `metadata`)
+so `dsh-skill`'s catalog lists all nine uniformly.
+
+- **License:** MIT, same as the repository (`LICENSE` at the repository root).
+- **Skill authors:** PaperMachine community; see each `SKILL.md` `metadata`.
+- **Environment assumption:** each skill's Installation table distinguishes
+  packages shipped in `biology.json` from packages installed on demand through
+  `install_science_packages`, and marks bioconda-only packages as macOS-only
+  (bioconda publishes no `win-64` builds). Skills remain usable on the `general`
+  environment: their first step then installs what the shipped set lacks.
+
+## Update method (biology skills)
+
+Edit in place. When `biology.json` gains or drops a package, update the matching
+Installation table row in every skill that names it, and the health-check import
+list in `biology.json`. Keep every `SKILL.md` body under roughly 1,400 words so
+the catalog entry plus body stays inside the model's context budget; move detail
+into `references/` and link it by path.

--- a/apps/desktop/resources/skills/bioassay-and-dose-response/SKILL.md
+++ b/apps/desktop/resources/skills/bioassay-and-dose-response/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: bioassay-and-dose-response
+description: "Wet-lab assay data analysis — dose–response curves (4PL/log-logistic, IC50/EC50/LD50 with CIs; scipy or R drc), microbial and cell growth curves (logistic/Gompertz fits, doubling time, lag, AUC), qPCR relative quantification (ΔΔCt, efficiency-corrected Pfaffl, reference-gene stability), ELISA and protein/DNA standard curves with back-calculation, Western blot and colony/plaque count comparisons, plate-layout aware replicate handling, Z′-factor for screening plates, and Michaelis–Menten enzyme kinetics. Use whenever a user has plate-reader output, Ct values, OD readings over time, concentrations vs response, or band intensities. Trigger terms: IC50、EC50、剂量反应、剂量效应、四参数、生长曲线、倍增时间、OD600、qPCR、ΔΔCt、2^-ΔΔCt、内参、标准曲线、ELISA、酶活、米氏、Km、Vmax、Z 因子、Western 定量、菌落计数."
+license: MIT license
+metadata:
+  version: "1.0"
+  skill-author: PaperMachine community
+---
+
+# Bioassay and Dose–Response Analysis
+
+Fit, compare, and plot bench-experiment data through `run_python` (scipy, statsmodels, pandas) or `run_r` (drc, emmeans, rstatix), writing fitted parameters, per-replicate tables, and figures to `SCIENCE_ARTIFACT_DIR`. The bar to clear: technical replicates are averaged **before** any test so that the unit of inference is the biological replicate; every fitted parameter has a confidence interval; the model is plotted over the raw points, not instead of them; and a curve that never reached its plateau is reported as "IC50 not estimable" rather than extrapolated.
+
+## Installation
+
+Shipped: `scipy` (`curve_fit`), `statsmodels`, `scikit-posthocs`, `r-drc`, `r-emmeans`, `r-rstatix`, `r-ggpubr`. Optional through `install_science_packages`:
+
+| Need | Language | Spec |
+|------|----------|------|
+| Plate-reader parsing helpers / growth curves in R | r | `r-growthcurver` (conda-forge) |
+| Robust nonlinear fits with profile-likelihood CIs | python | `lmfit` |
+| Mixed models for plate/day random effects (Python) | python | `statsmodels` already has `MixedLM`; R uses shipped `lme4` |
+| qPCR reference-gene stability (geNorm/NormFinder-like) | r | `bioconductor-normqpcr` (macOS) — or compute geNorm M with `scripts/qpcr.py` (shipped here, no install) |
+
+Compatibility traps: `curve_fit` needs sensible `p0` and `bounds` for 4PL or it silently converges to a flat line — always pass `p0=[bottom≈min(y), top≈max(y), ic50≈geometric mean of x, hill=1]` and check `pcov` is finite. Concentrations must be fitted on **log10(x)**; a zero-dose control cannot be logged — keep it as a separate constraint (fix `top` or `bottom`) or plot it at a nominal low value and say so. `drc::drm` uses `LL.4()` with parameters `(b = hill slope with sign flipped, c = lower, d = upper, e = ED50 on the linear scale)`; `ED(fit, 50, interval = "delta")` gives the CI. In `2^-ΔΔCt`, a Ct of 40 or "Undetermined" is a non-detect, not a number — handle it explicitly.
+
+## Workflow
+
+1. **Reconstruct the experiment.** Plate layout (which wells are which condition), technical vs biological replicates, blanks/negative and positive controls, units, and dilution series. If the file is a raw plate matrix, reshape it to long form (`well, row, col, condition, dose, replicate, value`) and print the layout as a table for the user to confirm. Subtract blanks and normalize to controls only after saying how (percent of vehicle; `(x − min)/(max − min)`).
+2. **Look before fitting.** Plot raw points per condition (log-x for doses, time-x for growth). Note saturation, incomplete curves, outliers, and edge-effects (rows A/H, columns 1/12 differ).
+3. **Fit the right model** (below), on biological-replicate means or with replicate as a random effect; report parameters with 95 % CIs, R² or residual SD, and a plot of the fitted curve over the raw points with the estimate marked. `scripts/dose_response.py` and `scripts/growth_curves.py` implement the fits with CIs; `scripts/qpcr.py` implements ΔΔCt and Pfaffl.
+4. **Compare conditions** with the appropriate test on the derived parameter (e.g. log IC50 or doubling time per biological replicate → t-test/ANOVA with emmeans/Tukey, or the F-test for nested curves in `drc::compParm`/`anova(fit_common, fit_separate)`). Never compare raw wells across treatments while ignoring the plate/day they came from; add `plate`/`day` as a blocking factor or random effect.
+5. **Deliver.** `fits.csv` (parameters, CIs, fit statistics per condition), `replicates.csv` (per-biological-replicate derived values), and PNG figures declared in `raster_artifacts`; `annotate_artifact` the main curve figure with model and n.
+
+## Models
+
+**Dose–response (4PL / log-logistic)** — `y = bottom + (top − bottom) / (1 + 10^((logIC50 − log x) · hill))`. Report IC50/EC50 in the original units with CI (from the covariance of `logIC50`: back-transform the interval, never symmetrize on the linear scale), the Hill slope, and whether top/bottom were fixed (0/100 for normalized data). Relative vs absolute IC50: the relative (curve midpoint) is what 4PL gives; the absolute (50 % of control) needs the top fixed at 100 — state which. Curves with < 4 doses spanning the transition, or no plateau, do not support an IC50. For binary outcomes (dead/alive counts → LD50), use a logit/probit GLM (`statsmodels.GLM(Binomial)`, `drc::LL.2` with `type="binomial"`) and Fieller-type CIs.
+
+**Growth curves** — logistic `N(t) = K / (1 + ((K − N0)/N0) e^{−r t})` or Gompertz (asymmetric); doubling time `ln 2 / r` from the exponential phase (log-linear fit on the window where log(OD) is linear, chosen by maximizing R² over sliding windows and printed), lag time (intercept of the tangent at max slope with the baseline), carrying capacity `K`, and AUC (trapezoid) as a model-free summary. Blank-subtract, then log-transform OD only for the exponential window; fit on the linear scale otherwise. Report the per-replicate doubling time and compare with ANOVA/emmeans.
+
+**qPCR** — Efficiency from a standard curve: `E = 10^(−1/slope) − 1` (accept 90–110 %, R² ≥ 0.98). ΔCt = Ct_target − Ct_ref (geometric mean of ≥ 2 reference genes when available); ΔΔCt = ΔCt_sample − mean ΔCt_calibrator; fold = `2^−ΔΔCt` (or Pfaffl with per-gene efficiencies). Statistics are done on **ΔCt (or ΔΔCt) values**, not on fold changes; report fold change with 95 % CI back-transformed from the ΔΔCt interval, plot on a log2 axis. Technical replicate Ct SD > 0.5 → flag the well. Reference-gene stability: geNorm M < 0.5 (homogeneous samples) / 1.0 (heterogeneous).
+
+**Standard curves (ELISA, BCA, Bradford, DNA)** — linear on the working range, or 4PL for sigmoidal ELISA; back-calculate unknowns with prediction intervals (`scripts/dose_response.py::inverse_predict`), flag values outside the calibrated range (never extrapolate above the top standard), apply dilution factors last, and report LOD/LOQ (mean blank + 3 SD / + 10 SD).
+
+**Enzyme kinetics** — Michaelis–Menten `v = Vmax [S]/(Km + [S])` by nonlinear fit (`curve_fit`, `drc::MM.2`); Lineweaver–Burk is for display only, never for estimation. Inhibition mode by global fit of competitive/non-competitive/uncompetitive models and AIC comparison.
+
+**Screening plates** — `Z′ = 1 − 3(σ_pos + σ_neg)/|μ_pos − μ_neg|`; Z′ ≥ 0.5 is assay-worthy. Normalize per plate (percent of controls or robust z-score with plate median/MAD), and show a plate heatmap to expose edge and gradient effects.
+
+**Counts (colonies, plaques, cells)** — Poisson/negative-binomial GLM with log(volume or dilution) offset rather than t-tests on raw counts; report rate ratios.
+
+## Integrity rules
+
+1. **The n reported is biological replicates.** Wells on the same plate from the same culture are technical replicates; average them first.
+2. **Fitted parameters come with CIs and the fit plotted over raw data.** A parameter table without a curve figure is not a result.
+3. **No extrapolated IC50/EC50, LOD-limited concentration, or fold change from non-detects.** Say "not estimable" or "> highest dose tested".
+4. **Normalization is disclosed**: blank subtraction, control definition, and any outlier removal with the rule (Grubbs/ROUT/none) and how many points it removed.
+5. **Statistics on the right scale**: log IC50, ΔCt, log doubling time — not on the back-transformed values.
+6. **Same model across compared conditions**, or a documented reason.
+7. **Seeds and versions** for any bootstrap CI (`np.random.default_rng(0)`; `scipy.__version__`).
+
+Files: `scripts/dose_response.py` (`fit_4pl`, `inverse_predict`, `plot_dose_response`), `scripts/qpcr.py` (`tidy_ct`, `ddct` — ΔΔCt or Pfaffl via `efficiencies=`, `genorm_m`, `efficiency_from_standard_curve`, and `fit_logistic` for growth curves with doubling time, lag, and AUC), `references/assay_qc.md` (acceptance criteria, plate effects, MIQE checklist, unit conversions).

--- a/apps/desktop/resources/skills/bioassay-and-dose-response/references/assay_qc.md
+++ b/apps/desktop/resources/skills/bioassay-and-dose-response/references/assay_qc.md
@@ -1,0 +1,39 @@
+# Assay QC, acceptance criteria, and reporting checklists
+
+## Acceptance criteria (state them, then apply them)
+
+| Assay | Criterion | Typical threshold |
+|-------|-----------|-------------------|
+| Any plate | Z′-factor from positive/negative controls | ≥ 0.5 good; 0–0.5 marginal; < 0 unusable |
+| Any plate | CV of replicate wells | ≤ 15 % (≤ 20 % near LOQ) |
+| Dose–response | Doses spanning both plateaus, ≥ 6 concentrations, ≥ 3 biological replicates | IC50 inside the tested range; Hill slope 0.5–3 plausible |
+| qPCR | Efficiency 90–110 %, standard-curve R² ≥ 0.98, technical Ct SD ≤ 0.5, NTC Ct ≥ 35 or undetermined, single melt peak | Reference genes geNorm M < 0.5 (1.0 heterogeneous) |
+| ELISA / standard curve | Back-calculated standards within ±20 % of nominal (±25 % at LLOQ), 4PL R² ≥ 0.99 | Unknowns inside the calibrated range |
+| Growth curves | Blank OD stable; ≥ 5 points in exponential phase; R² of log-linear window ≥ 0.98 | Doubling time reported per replicate |
+| Western blot | Loading-control band in the linear range (check a dilution series once), same membrane for compared lanes | Normalize to total protein where possible |
+| Counts | ≥ 30 and ≤ 300 colonies per plate (or the countable range for the organism) | Use plates within range only |
+
+## Plate and day effects
+
+- Edge wells evaporate: rows A/H and columns 1/12 read differently. Plot a plate heatmap of raw values; if edges deviate, exclude them or include `edge` as a covariate — and say so.
+- Day-to-day and plate-to-plate offsets are real: normalize within plate to that plate's controls, then analyze biological replicates as blocks (`plate`/`day` as a random effect in `MixedLM`/`lmer`, or as a factor in ANOVA).
+- Gradients (temperature, pipetting order) show up as smooth trends across columns; randomized layouts prevent confounding with treatment — note when the layout was not randomized.
+
+## Outliers
+
+Decide the rule before looking at which points are inconvenient: Grubbs (single outlier, normal data), ROUT (robust regression, Q = 1 %), or none. Report the rule and the number removed; keep removed points visible (hollow markers) in the figure.
+
+## MIQE-style qPCR reporting (minimum)
+
+Sample type and RNA extraction; RNA integrity (RIN) if measured; reverse-transcription kit and input; primer sequences or assay IDs and amplicon sizes; efficiency and R² per assay; reference genes and their stability metric; number of biological and technical replicates; Ct threshold method; how non-detects were handled; the statistical test and on which scale (ΔCt).
+
+## Units and conversions
+
+- Molarity ↔ mass: `conc (µM) = mass_conc (µg/mL) / MW (g/mol) × 1000`.
+- OD600 → cells/mL is strain- and instrument-specific (E. coli ≈ 8 × 10⁸ cells/mL per OD unit as a rough default) — report OD, convert only with a calibration.
+- Serial dilutions: concentration at step k = C₀ / f^k; log10 spacing = log10(f).
+- Percent inhibition = 100 × (1 − (x − neg)/(pos − neg)) with `neg` = no-inhibition control and `pos` = full-inhibition control.
+
+## Figure conventions
+
+Dose–response: log-x, points as mean ± SD with n in the legend, fitted curve, IC50 with CI marked; separate panels per experiment day if curves are pooled. Growth: linear-y OD and a log-y inset or second panel showing the exponential window used. qPCR: log2 fold-change axis, individual biological replicates as points over bars or as a dot plot, calibrator at 1. Standard curve: standards, fitted curve with the calibrated range shaded, unknowns marked, extrapolated unknowns hollow.

--- a/apps/desktop/resources/skills/bioassay-and-dose-response/scripts/dose_response.py
+++ b/apps/desktop/resources/skills/bioassay-and-dose-response/scripts/dose_response.py
@@ -1,0 +1,128 @@
+"""4PL dose–response fitting with CIs, inverse prediction for standard curves, and a standard figure.
+
+    exec(open(f"{SKILL_DIR}/scripts/dose_response.py").read())
+    fit = fit_4pl(x_conc, y_response, fix_top=100, fix_bottom=0)     # normalized data
+    fit["ic50"], fit["ic50_ci95"], fit["hill"], fit["r2"]
+    fig = plot_dose_response({"Drug A": (xa, ya, fit_a), "Drug B": (xb, yb, fit_b)}, x_label="Concentration (µM)")
+    conc = inverse_predict(fit_std, y_unknown)                          # standards → unknowns with 95% PI
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from scipy.optimize import curve_fit
+from scipy import stats
+
+
+def four_pl(logx, bottom, top, logic50, hill):
+    return bottom + (top - bottom) / (1 + 10 ** ((logic50 - logx) * hill))
+
+
+def fit_4pl(x, y, fix_top=None, fix_bottom=None, weights=None) -> dict:
+    """Fit a 4PL on log10(x). x must be > 0 (drop the zero-dose control or handle it via fix_top/fix_bottom).
+    Returns dict with parameters, SEs, 95% CIs (IC50 CI back-transformed from log scale), r2, residual SD, n, and
+    a callable `predict(x)`. `weights` = 1/SD per point for weighted least squares if replicate SDs are known."""
+    x = np.asarray(x, float); y = np.asarray(y, float)
+    mask = np.isfinite(x) & np.isfinite(y) & (x > 0)
+    x, y = x[mask], y[mask]
+    lx = np.log10(x)
+    p0 = [np.nanmin(y) if fix_bottom is None else fix_bottom, np.nanmax(y) if fix_top is None else fix_top,
+          np.mean(lx), 1.0]
+
+    free = [fix_bottom is None, fix_top is None, True, True]
+    names = np.array(["bottom", "top", "logic50", "hill"])
+
+    def model(lx_, *params):
+        full = list(p0)
+        it = iter(params)
+        for i, f in enumerate(free):
+            if f:
+                full[i] = next(it)
+        return four_pl(lx_, *full)
+
+    p0_free = [p for p, f in zip(p0, free) if f]
+    lower = [-np.inf if n != "hill" else 0.05 for n, f in zip(names, free) if f]
+    upper = [np.inf if n != "hill" else 10 for n, f in zip(names, free) if f]
+    sigma = None if weights is None else 1 / np.asarray(weights, float)[mask]
+    popt, pcov = curve_fit(model, lx, y, p0=p0_free, bounds=(lower, upper), sigma=sigma, maxfev=20000)
+    if not np.all(np.isfinite(pcov)):
+        raise RuntimeError("4PL fit did not converge to a well-conditioned solution; check the dose range and plateaus")
+    perr = np.sqrt(np.diag(pcov))
+    dof = max(len(y) - len(popt), 1)
+    tcrit = stats.t.ppf(0.975, dof)
+    full = list(p0); se = [0.0] * 4; it = iter(range(len(popt)))
+    for i, f in enumerate(free):
+        if f:
+            k = next(it); full[i] = popt[k]; se[i] = perr[k]
+    bottom, top, logic50, hill = full
+    yhat = four_pl(lx, *full)
+    ss_res = np.sum((y - yhat) ** 2); ss_tot = np.sum((y - y.mean()) ** 2)
+    ic50_ci = (10 ** (logic50 - tcrit * se[2]), 10 ** (logic50 + tcrit * se[2]))
+    x_range = (x.min(), x.max())
+    plateau_note = None
+    if 10 ** logic50 < x_range[0] or 10 ** logic50 > x_range[1]:
+        plateau_note = "IC50 lies outside the tested dose range — report as not estimable"
+    result = dict(bottom=bottom, top=top, logic50=logic50, ic50=10 ** logic50, ic50_ci95=ic50_ci, hill=hill,
+                  se=dict(zip(names, se)), r2=1 - ss_res / ss_tot if ss_tot > 0 else np.nan,
+                  residual_sd=np.sqrt(ss_res / dof), n=len(y), dof=dof, fixed=dict(top=fix_top, bottom=fix_bottom),
+                  dose_range=x_range, warning=plateau_note,
+                  predict=lambda xx: four_pl(np.log10(np.asarray(xx, float)), bottom, top, logic50, hill),
+                  _cov=pcov, _free=free, _p0=p0)
+    return result
+
+
+def inverse_predict(fit: dict, y_new, level: float = 0.95) -> pd.DataFrame:
+    """Back-calculate concentrations from responses on a fitted 4PL standard curve, with an approximate
+    prediction interval (delta method on log10 x plus residual SD). Flags out-of-range values."""
+    bottom, top, logic50, hill = fit["bottom"], fit["top"], fit["logic50"], fit["hill"]
+    y_new = np.asarray(y_new, float)
+    rows = []
+    lo_y, hi_y = sorted([bottom, top])
+    for yv in y_new:
+        if not (lo_y < yv < hi_y):
+            rows.append(dict(response=yv, conc=np.nan, conc_lower=np.nan, conc_upper=np.nan, flag="outside curve asymptotes"))
+            continue
+        ratio = (top - bottom) / (yv - bottom) - 1
+        lx = logic50 - np.log10(ratio) / hill
+        # slope dy/dlogx at lx, for an approximate interval from the residual SD
+        h = 1e-4
+        slope = (four_pl(lx + h, bottom, top, logic50, hill) - four_pl(lx - h, bottom, top, logic50, hill)) / (2 * h)
+        tcrit = stats.t.ppf(0.5 + level / 2, fit["dof"])
+        half = tcrit * fit["residual_sd"] / abs(slope) if slope != 0 else np.inf
+        conc = 10 ** lx
+        flag = ""
+        if conc < fit["dose_range"][0] or conc > fit["dose_range"][1]:
+            flag = "outside calibrated range — extrapolated"
+        rows.append(dict(response=yv, conc=conc, conc_lower=10 ** (lx - half), conc_upper=10 ** (lx + half), flag=flag))
+    return pd.DataFrame(rows)
+
+
+def plot_dose_response(curves: dict, x_label: str = "Concentration", y_label: str = "Response (% of control)",
+                       title: str = "Dose–response", show_ic50: bool = True):
+    """curves: {label: (x, y, fit_dict)} — raw points plotted as mean ± SD per dose, fitted curve on top,
+    IC50 marked with its CI as a horizontal bar at the half-max level."""
+    fig, ax = plt.subplots(figsize=(7, 5))
+    palette = plt.rcParams["axes.prop_cycle"].by_key()["color"]
+    for i, (label, (x, y, fit)) in enumerate(curves.items()):
+        c = palette[i % len(palette)]
+        df = pd.DataFrame({"x": np.asarray(x, float), "y": np.asarray(y, float)})
+        df = df[df.x > 0]
+        agg = df.groupby("x")["y"].agg(["mean", "std", "count"]).reset_index()
+        ax.errorbar(agg["x"], agg["mean"], yerr=agg["std"], fmt="o", color=c, capsize=3, ms=5, label=f"{label} (points, mean ± SD)")
+        grid = np.logspace(np.log10(df.x.min()) - 0.3, np.log10(df.x.max()) + 0.3, 200)
+        ic50 = fit["ic50"]; lo, hi = fit["ic50_ci95"]
+        ax.plot(grid, fit["predict"](grid), color=c, lw=2,
+                label=f"{label}: IC50 = {ic50:.3g} ({lo:.3g}–{hi:.3g}), Hill = {fit['hill']:.2f}")
+        if show_ic50:
+            half = fit["bottom"] + (fit["top"] - fit["bottom"]) / 2
+            ax.plot([lo, hi], [half, half], color=c, lw=4, alpha=0.35)
+            ax.axvline(ic50, color=c, ls=":", lw=1)
+    ax.set_xscale("log")
+    ax.set_xlabel(x_label); ax.set_ylabel(y_label); ax.set_title(title)
+    ax.grid(alpha=0.25, which="both")
+    ax.legend(fontsize=8, frameon=False)
+    fig.tight_layout()
+    return fig

--- a/apps/desktop/resources/skills/bioassay-and-dose-response/scripts/dose_response.py
+++ b/apps/desktop/resources/skills/bioassay-and-dose-response/scripts/dose_response.py
@@ -18,7 +18,8 @@ from scipy import stats
 
 
 def four_pl(logx, bottom, top, logic50, hill):
-    return bottom + (top - bottom) / (1 + 10 ** ((logic50 - logx) * hill))
+    exponent = np.clip((logic50 - logx) * hill, -100.0, 100.0)
+    return bottom + (top - bottom) / (1.0 + np.power(10.0, exponent))
 
 
 def fit_4pl(x, y, fix_top=None, fix_bottom=None, weights=None) -> dict:
@@ -60,12 +61,18 @@ def fit_4pl(x, y, fix_top=None, fix_bottom=None, weights=None) -> dict:
     bottom, top, logic50, hill = full
     yhat = four_pl(lx, *full)
     ss_res = np.sum((y - yhat) ** 2); ss_tot = np.sum((y - y.mean()) ** 2)
-    ic50_ci = (10 ** (logic50 - tcrit * se[2]), 10 ** (logic50 + tcrit * se[2]))
+    lo_ci_exp = logic50 - tcrit * se[2]
+    hi_ci_exp = logic50 + tcrit * se[2]
+    ic50_ci = (
+        float(np.power(10.0, lo_ci_exp)) if lo_ci_exp > -300 else 0.0,
+        float(np.power(10.0, hi_ci_exp)) if hi_ci_exp < 300 else np.inf,
+    )
+    ic50 = float(np.power(10.0, logic50)) if logic50 < 300 else np.inf
     x_range = (x.min(), x.max())
     plateau_note = None
-    if 10 ** logic50 < x_range[0] or 10 ** logic50 > x_range[1]:
+    if ic50 < x_range[0] or ic50 > x_range[1]:
         plateau_note = "IC50 lies outside the tested dose range — report as not estimable"
-    result = dict(bottom=bottom, top=top, logic50=logic50, ic50=10 ** logic50, ic50_ci95=ic50_ci, hill=hill,
+    result = dict(bottom=bottom, top=top, logic50=logic50, ic50=ic50, ic50_ci95=ic50_ci, hill=hill,
                   se=dict(zip(names, se)), r2=1 - ss_res / ss_tot if ss_tot > 0 else np.nan,
                   residual_sd=np.sqrt(ss_res / dof), n=len(y), dof=dof, fixed=dict(top=fix_top, bottom=fix_bottom),
                   dose_range=x_range, warning=plateau_note,
@@ -86,17 +93,22 @@ def inverse_predict(fit: dict, y_new, level: float = 0.95) -> pd.DataFrame:
             rows.append(dict(response=yv, conc=np.nan, conc_lower=np.nan, conc_upper=np.nan, flag="outside curve asymptotes"))
             continue
         ratio = (top - bottom) / (yv - bottom) - 1
+        if ratio <= 0:
+            rows.append(dict(response=yv, conc=np.nan, conc_lower=np.nan, conc_upper=np.nan, flag="outside curve asymptotes"))
+            continue
         lx = logic50 - np.log10(ratio) / hill
         # slope dy/dlogx at lx, for an approximate interval from the residual SD
         h = 1e-4
         slope = (four_pl(lx + h, bottom, top, logic50, hill) - four_pl(lx - h, bottom, top, logic50, hill)) / (2 * h)
         tcrit = stats.t.ppf(0.5 + level / 2, fit["dof"])
         half = tcrit * fit["residual_sd"] / abs(slope) if slope != 0 else np.inf
-        conc = 10 ** lx
+        conc = float(np.power(10.0, lx)) if lx < 300 else np.inf
         flag = ""
         if conc < fit["dose_range"][0] or conc > fit["dose_range"][1]:
             flag = "outside calibrated range — extrapolated"
-        rows.append(dict(response=yv, conc=conc, conc_lower=10 ** (lx - half), conc_upper=10 ** (lx + half), flag=flag))
+        conc_lower = float(np.power(10.0, lx - half)) if (lx - half) > -300 else 0.0
+        conc_upper = float(np.power(10.0, lx + half)) if (lx + half) < 300 else np.inf
+        rows.append(dict(response=yv, conc=conc, conc_lower=conc_lower, conc_upper=conc_upper, flag=flag))
     return pd.DataFrame(rows)
 
 

--- a/apps/desktop/resources/skills/bioassay-and-dose-response/scripts/qpcr.py
+++ b/apps/desktop/resources/skills/bioassay-and-dose-response/scripts/qpcr.py
@@ -1,0 +1,134 @@
+"""qPCR relative quantification (ΔΔCt, Pfaffl), geNorm M, and standard-curve efficiency;
+plus logistic growth-curve fitting with doubling time.
+
+    exec(open(f"{SKILL_DIR}/scripts/qpcr.py").read())
+    long = tidy_ct(df)   # columns: sample, group, gene, replicate, ct   (ct NaN for Undetermined)
+    res = ddct(long, target="IL6", references=["GAPDH", "ACTB"], calibrator_group="control")
+    eff = efficiency_from_standard_curve(log10_input, ct)
+    M = genorm_m(long, genes=["GAPDH", "ACTB", "B2M", "HPRT1"])
+    g = fit_logistic(t_hours, od600); g["doubling_time"], g["lag"], g["K"]
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from scipy import stats
+from scipy.optimize import curve_fit
+
+UNDETERMINED_CT = 40.0   # treat Ct >= this as a non-detect
+
+
+def tidy_ct(df: pd.DataFrame, ct_col: str = "ct") -> pd.DataFrame:
+    """Coerce 'Undetermined'/'NaN'/'>40' to NaN and Ct >= UNDETERMINED_CT to NaN; keep a `nondetect` flag."""
+    out = df.copy()
+    out[ct_col] = pd.to_numeric(out[ct_col], errors="coerce")
+    out["nondetect"] = out[ct_col].isna() | (out[ct_col] >= UNDETERMINED_CT)
+    out.loc[out["nondetect"], ct_col] = np.nan
+    return out
+
+
+def _tech_mean(long: pd.DataFrame) -> pd.DataFrame:
+    """Average technical replicates per (sample, gene); flag SD > 0.5 cycles."""
+    g = long.groupby(["sample", "group", "gene"], observed=True)["ct"]
+    agg = g.agg(ct_mean="mean", ct_sd="std", n_tech="count", n_nondetect=lambda s: s.isna().sum()).reset_index()
+    agg["flag_tech_sd_gt_0.5"] = agg["ct_sd"] > 0.5
+    return agg
+
+
+def ddct(long: pd.DataFrame, target: str, references: list[str], calibrator_group: str,
+         efficiencies: dict[str, float] | None = None) -> dict:
+    """2^-ΔΔCt (or Pfaffl when `efficiencies` gives per-gene E as a fraction, e.g. 0.97) with statistics on ΔCt.
+    Returns {"per_sample": DataFrame, "summary": DataFrame (fold change with 95% CI per group), "test": dict}."""
+    tm = _tech_mean(long)
+    wide = tm.pivot_table(index=["sample", "group"], columns="gene", values="ct_mean").reset_index()
+    ref_ct = wide[references].mean(axis=1) if efficiencies is None else np.log2(
+        np.prod([(1 + efficiencies[r]) ** (-wide[r]) for r in references], axis=0) ** (1 / len(references))) * -1
+    # ΔCt = Ct_target − geometric-mean-equivalent Ct_ref  (arithmetic mean of Ct == geometric mean of quantities)
+    wide["dct"] = wide[target] - ref_ct
+    cal = wide.loc[wide["group"] == calibrator_group, "dct"]
+    if cal.empty:
+        raise ValueError(f"calibrator group '{calibrator_group}' has no samples")
+    wide["ddct"] = wide["dct"] - cal.mean()
+    e_t = 2.0 if efficiencies is None else 1 + efficiencies[target]
+    wide["fold_change"] = e_t ** (-wide["ddct"])
+    wide["nondetect_target"] = wide[target].isna()
+
+    rows = []
+    for grp, sub in wide.groupby("group", observed=True):
+        d = sub["ddct"].dropna()
+        n = len(d)
+        if n >= 2:
+            se = d.std(ddof=1) / np.sqrt(n); t = stats.t.ppf(0.975, n - 1)
+            lo, hi = d.mean() - t * se, d.mean() + t * se
+        else:
+            lo = hi = np.nan
+        rows.append(dict(group=grp, n_bio=n, mean_ddct=d.mean(), fold_change=e_t ** (-d.mean()),
+                         fc_lower95=e_t ** (-hi), fc_upper95=e_t ** (-lo)))
+    summary = pd.DataFrame(rows)
+
+    test = {}
+    groups = [g for g in wide["group"].unique() if g != calibrator_group]
+    for grp in groups:
+        a = wide.loc[wide.group == calibrator_group, "dct"].dropna(); b = wide.loc[wide.group == grp, "dct"].dropna()
+        if len(a) >= 2 and len(b) >= 2:
+            t = stats.ttest_ind(b, a, equal_var=False)
+            test[grp] = dict(comparison=f"{grp} vs {calibrator_group}", welch_t=t.statistic, p=t.pvalue, scale="ΔCt")
+    return {"per_sample": wide, "summary": summary, "test": test, "technical": tm}
+
+
+def efficiency_from_standard_curve(log10_input, ct) -> dict:
+    """Slope/intercept/R² of Ct vs log10(input) and amplification efficiency E = 10^(−1/slope) − 1."""
+    x = np.asarray(log10_input, float); y = np.asarray(ct, float)
+    m = np.isfinite(x) & np.isfinite(y)
+    res = stats.linregress(x[m], y[m])
+    eff = 10 ** (-1 / res.slope) - 1
+    return dict(slope=res.slope, intercept=res.intercept, r2=res.rvalue ** 2, efficiency=eff,
+                efficiency_pct=100 * eff, acceptable=(0.90 <= eff <= 1.10) and res.rvalue ** 2 >= 0.98)
+
+
+def genorm_m(long: pd.DataFrame, genes: list[str]) -> pd.Series:
+    """geNorm stability measure M per candidate reference gene (lower = more stable; < 0.5 homogeneous samples)."""
+    tm = _tech_mean(long)
+    wide = tm.pivot_table(index="sample", columns="gene", values="ct_mean")[genes]
+    q = 2.0 ** (-wide)                                      # relative quantities
+    M = {}
+    for g in genes:
+        vs = [np.log2(q[g] / q[h]).std(ddof=1) for h in genes if h != g]
+        M[g] = float(np.mean(vs))
+    return pd.Series(M, name="geNorm_M").sort_values()
+
+
+# --- growth curves ---------------------------------------------------------------
+
+def logistic(t, K, N0, r):
+    return K / (1 + ((K - N0) / N0) * np.exp(-r * t))
+
+
+def fit_logistic(t, od, blank: float = 0.0) -> dict:
+    """Logistic fit on blank-subtracted OD; doubling time from r and from the best log-linear window; lag time
+    by the tangent-at-max-slope method; AUC as a model-free summary."""
+    t = np.asarray(t, float); y = np.asarray(od, float) - blank
+    m = np.isfinite(t) & np.isfinite(y) & (y > 0)
+    t, y = t[m], y[m]
+    p0 = [y.max(), max(y[0], 1e-4), 0.5]
+    popt, pcov = curve_fit(logistic, t, y, p0=p0, bounds=([0, 1e-6, 1e-4], [np.inf, np.inf, 50]), maxfev=20000)
+    K, N0, r = popt
+    perr = np.sqrt(np.diag(pcov))
+    # best exponential window: maximize R² of log(y) ~ t over windows of >= 5 points
+    best = None
+    ly = np.log(y)
+    for w in range(5, len(t) + 1):
+        for i in range(0, len(t) - w + 1):
+            lr = stats.linregress(t[i:i + w], ly[i:i + w])
+            if lr.slope > 0 and (best is None or lr.rvalue ** 2 > best[0]):
+                best = (lr.rvalue ** 2, lr.slope, t[i], t[i + w - 1])
+    mu_max = best[1] if best else np.nan
+    # lag: tangent at the point of maximum slope of the fitted curve intersects baseline N0
+    grid = np.linspace(t.min(), t.max(), 1000); fit_y = logistic(grid, *popt)
+    slope = np.gradient(fit_y, grid); k = int(np.argmax(slope))
+    lag = grid[k] - (fit_y[k] - N0) / slope[k] if slope[k] > 0 else np.nan
+    yhat = logistic(t, *popt); r2 = 1 - np.sum((y - yhat) ** 2) / np.sum((y - y.mean()) ** 2)
+    return dict(K=K, N0=N0, r=r, se=dict(K=perr[0], N0=perr[1], r=perr[2]),
+                doubling_time_model=np.log(2) / r, doubling_time_window=np.log(2) / mu_max if mu_max else np.nan,
+                window=(best[2], best[3], best[0]) if best else None, lag=max(lag, 0) if np.isfinite(lag) else np.nan,
+                auc=np.trapz(y, t), r2=r2, predict=lambda tt: logistic(np.asarray(tt, float), *popt))

--- a/apps/desktop/resources/skills/bioassay-and-dose-response/scripts/qpcr.py
+++ b/apps/desktop/resources/skills/bioassay-and-dose-response/scripts/qpcr.py
@@ -128,7 +128,9 @@ def fit_logistic(t, od, blank: float = 0.0) -> dict:
     slope = np.gradient(fit_y, grid); k = int(np.argmax(slope))
     lag = grid[k] - (fit_y[k] - N0) / slope[k] if slope[k] > 0 else np.nan
     yhat = logistic(t, *popt); r2 = 1 - np.sum((y - yhat) ** 2) / np.sum((y - y.mean()) ** 2)
+    trapz_fn = getattr(np, "trapezoid", getattr(np, "trapz", None))
+    auc = float(trapz_fn(y, t)) if trapz_fn is not None else np.nan
     return dict(K=K, N0=N0, r=r, se=dict(K=perr[0], N0=perr[1], r=perr[2]),
                 doubling_time_model=np.log(2) / r, doubling_time_window=np.log(2) / mu_max if mu_max else np.nan,
                 window=(best[2], best[3], best[0]) if best else None, lag=max(lag, 0) if np.isfinite(lag) else np.nan,
-                auc=np.trapz(y, t), r2=r2, predict=lambda tt: logistic(np.asarray(tt, float), *popt))
+                auc=auc, r2=r2, predict=lambda tt: logistic(np.asarray(tt, float), *popt))

--- a/apps/desktop/resources/skills/bulk-rnaseq-analysis/SKILL.md
+++ b/apps/desktop/resources/skills/bulk-rnaseq-analysis/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: bulk-rnaseq-analysis
+description: "Bulk RNA-seq downstream analysis from a gene × sample count matrix — count QC, library-size normalization, PCA/sample clustering, differential expression (pyDESeq2 in Python; DESeq2/edgeR/limma-voom in R), volcano/MA/heatmap figures, and GO/KEGG over-representation or GSEA enrichment. Use whenever a user has a count table, featureCounts/HTSeq/Salmon/kallisto output, a DE result table, or asks which genes change between conditions. Trigger terms: 差异表达、RNA-seq、转录组、counts 矩阵、火山图、DESeq2、edgeR、limma、GO/KEGG 富集、GSEA、热图."
+license: MIT license
+metadata:
+  version: "1.0"
+  skill-author: PaperMachine community
+---
+
+# Bulk RNA-seq Analysis
+
+Take a count matrix to a defensible differential-expression result through `run_python` or `run_r`: inspect and filter counts, model the design, test, correct for multiple testing, plot, and enrich. The standard a reviewer applies is simple — the design was stated before testing, low counts were filtered honestly, shrunken fold changes are reported alongside adjusted p-values, and every figure traces back to one result table.
+
+## Installation
+
+The `biology` environment ships pandas, scipy, statsmodels, scikit-learn, seaborn, and R's tidyverse, pheatmap, ggpubr, rstatix. Add DE engines through `install_science_packages`, never through in-kernel `pip`/`install.packages()`:
+
+| Need | Language | Spec |
+|------|----------|------|
+| DE (default, works on every platform) | python | `pydeseq2` |
+| Enrichment (ORA + prerank GSEA, Enrichr libraries) | python | `gseapy` |
+| DE (macOS only — bioconda ships no Windows builds) | r | `bioconductor-deseq2`, `bioconductor-edger`, `bioconductor-limma` |
+| Enrichment in R (macOS only) | r | `bioconductor-clusterprofiler`, `bioconductor-org.hs.eg.db` (or `org.mm.eg.db`) |
+| Gene ID mapping | python | `mygene` |
+
+If an R Bioconductor install reports `failed`, do not fall back to `BiocManager::install()` inside the kernel; switch to the Python path (`pydeseq2` + `gseapy`), which is functionally equivalent for the two-group and multi-factor designs below. Compatibility traps: `pydeseq2>=0.5` takes `design="~ condition"` (formula string) instead of `design_factors=`; `gseapy` Enrichr libraries require network access — when offline, ask for a local GMT file and pass it as `gene_sets=`.
+
+## Workflow
+
+Work in order; each step's output feeds the next, and the skipped step is the one reviewers ask about.
+
+1. **Load and orient the matrix.** Rows must be genes, columns samples, values raw integer counts (not TPM/FPKM — DESeq2/edgeR models reject normalized input; for Salmon/kallisto import TPM+counts with `tximport` in R or sum `NumReads`). Print shape, `head`, dtype, and confirm sample names match the metadata sheet exactly. State the design formula now (`~ batch + condition`) and which contrast answers the question. Choosing contrasts after peeking is p-hacking.
+2. **Count QC.** Library sizes (bar chart), fraction of zero counts per sample, sample–sample correlation heatmap on log2(CPM+1), and PCA of variance-stabilized counts (`vst`/`rlog` in R, `log1p(CPM)` of the top 2,000 most variable genes in Python). Colour PCA by condition **and** by batch/sequencing run; an outlier or a batch axis explaining PC1 is a finding to report, not something to silently regress away. `scripts/count_qc.py` produces all four figures from one call.
+3. **Filter low counts.** Keep genes with ≥10 counts in at least the smallest group size number of samples (edgeR's `filterByExpr` rule). Report how many genes remain of how many.
+4. **Fit and test.** pyDESeq2: `DeseqDataSet(counts=counts.T, metadata=meta, design="~ condition")` → `.deseq2()` → `DeseqStats(dds, contrast=["condition","treated","control"])` → `.summary()` → `.lfc_shrink(coeff="condition[T.treated]")`. R: `DESeqDataSetFromMatrix` → `DESeq` → `results(..., alpha=0.05)` → `lfcShrink(type="apeglm")`. Always shrink log fold changes before ranking or plotting; report both `log2FoldChange` and `padj` (BH). With no replicates in a group, say plainly that no valid DE test exists and stop at descriptive fold changes.
+5. **Write the result table** to `SCIENCE_ARTIFACT_DIR/de_results.csv` sorted by `padj`, with columns `gene, baseMean, log2FoldChange, lfcSE, pvalue, padj`. Every figure below is drawn from this file, never from a second in-memory copy.
+6. **Figures.** Volcano (log2FC vs −log10 padj, thresholds |log2FC| ≥ 1 and padj < 0.05 drawn as lines, top 15 genes labelled), MA plot, and a heatmap of the top 30–50 DE genes on z-scored VST counts with a condition colour bar. Save each as PNG under `SCIENCE_ARTIFACT_DIR` with `fig.savefig()` (matplotlib) or `ggsave()` (ggplot2) and declare it in `raster_artifacts`. Use `annotate_artifact` on the volcano with the contrast and thresholds in the caption.
+7. **Enrichment.** ORA (`gseapy.enrichr` or `clusterProfiler::enrichGO`) on significant up- and down-regulated genes separately, using **all tested genes as the background**, never the whole genome. GSEA (`gseapy.prerank` on the shrunken log2FC ranking, `permutation_num=1000`, `seed=0`) when the user wants pathway-level direction. Report term, gene ratio, adjusted p, and leading-edge genes; plot a dot plot of the top 15 terms. `references/enrichment.md` covers ID conversion and library choice.
+8. **Report.** Design and contrast, filtering rule and gene counts, normalization method, number of DE genes at the stated thresholds (up/down), the top genes with shrunken log2FC and padj, and the enrichment method with background definition.
+
+## Design guidance
+
+- **Batch.** If batch is known and not confounded with condition, put it in the formula (`~ batch + condition`). If it is fully confounded, no model can separate them — say so.
+- **Paired samples** (before/after per patient): `~ subject + condition`.
+- **Interaction** (drug × genotype): `~ genotype + drug + genotype:drug`; the interaction term, not the drug main effect, answers "does the drug act differently by genotype".
+- **Continuous covariate** (age, dose): keep numeric; centre it. Do not bin unless the user asks.
+- **Three or more levels:** one likelihood-ratio test for "any difference", then pairwise contrasts each with its own BH correction; state which comparison each figure shows.
+
+## Integrity rules
+
+1. **Never filter on p-value before enrichment background is fixed.** Background = genes that passed the low-count filter.
+2. **Do not change the log2FC or padj threshold to obtain a non-empty gene list.** Report the empty list and show the top-ranked genes descriptively.
+3. **Adjusted p-values are the reported values.** Raw p-values appear in the table but are never used to call significance.
+4. **A gene with padj < 0.05 and |log2FC| < 0.3 is statistically detected, not biologically compelling** — say both.
+5. **Heatmaps are z-scored per gene; say so in the caption.** Colour scales must be symmetric around zero.
+6. **Set seeds** for GSEA permutations and any subsampling, and print `pydeseq2.__version__` / `packageVersion("DESeq2")` into the report.
+
+## Quick reference
+
+- Count → CPM: `cpm = counts / counts.sum(0) * 1e6`; log2(CPM + 1) for plotting only.
+- pyDESeq2 result frame columns: `baseMean, log2FoldChange, lfcSE, stat, pvalue, padj` (index = gene). After `lfc_shrink`, `log2FoldChange` is replaced in place — copy the unshrunk column first if the user wants both.
+- edgeR path: `DGEList` → `filterByExpr` → `calcNormFactors` → `model.matrix` → `glmQLFit` → `glmQLFTest` → `topTags(n=Inf)`.
+- limma-voom for large n or continuous designs: `voom(dge, design, plot=TRUE)` → `lmFit` → `eBayes` → `topTable(coef=, n=Inf)`.
+- More: `references/de_methods.md` (method choice, when DESeq2 vs edgeR vs limma), `references/enrichment.md`, `scripts/count_qc.py`, `scripts/volcano.py`.

--- a/apps/desktop/resources/skills/bulk-rnaseq-analysis/references/de_methods.md
+++ b/apps/desktop/resources/skills/bulk-rnaseq-analysis/references/de_methods.md
@@ -1,0 +1,88 @@
+# Choosing and running a differential-expression method
+
+## Which engine
+
+| Situation | Use | Why |
+|-----------|-----|-----|
+| 2–10 replicates per group, standard two-group or factorial design | DESeq2 / pyDESeq2 | Robust dispersion shrinkage, apeglm LFC shrinkage, sensible defaults |
+| Many samples (≥ 20 per group), continuous covariates, or complex random effects via `duplicateCorrelation` | limma-voom | Linear-model flexibility; fast; well-calibrated with large n |
+| Very low counts, quasi-likelihood F-test preferred by reviewers, or when the lab's pipeline is edgeR | edgeR QL | `glmQLFit`/`glmQLFTest` controls type I error tightly |
+| Windows machine (no bioconda) | pyDESeq2 | Pure Python, conda-forge/bioconda noarch |
+| No replicates | none | Only descriptive log2FC; state that no inferential test is valid |
+
+All three agree on the large majority of calls for well-replicated data. Report the one you used and its version; do not run all three and pick the longest list.
+
+## pyDESeq2 minimal path (`>= 0.5`)
+
+```python
+from pydeseq2.dds import DeseqDataSet
+from pydeseq2.ds import DeseqStats
+
+# counts: genes x samples integer DataFrame; meta: samples x covariates
+keep = filter_by_expr(counts, meta["condition"])
+dds = DeseqDataSet(counts=counts.loc[keep].T, metadata=meta, design="~ batch + condition", quiet=True)
+dds.deseq2()
+stat = DeseqStats(dds, contrast=["condition", "treated", "control"], alpha=0.05, quiet=True)
+stat.summary()                                   # prints; stat.results_df holds the table
+unshrunk = stat.results_df["log2FoldChange"].copy()
+stat.lfc_shrink(coeff="condition[T.treated]")    # replaces log2FoldChange in place
+res = stat.results_df.assign(log2FoldChange_unshrunk=unshrunk).sort_values("padj")
+res.index.name = "gene"
+res.to_csv(f"{SCIENCE_ARTIFACT_DIR}/de_results.csv")
+```
+
+The `coeff` name follows patsy/formulaic conventions: `<factor>[T.<level>]` where `<level>` is the non-reference level. Print `dds.obsm["design_matrix"].columns` if unsure. Set the reference level explicitly by ordering the categorical: `meta["condition"] = pd.Categorical(meta["condition"], ["control", "treated"])`.
+
+Variance-stabilized values for heatmaps/PCA: `dds.vst()` then `dds.layers["vst_counts"]` (samples × genes).
+
+## DESeq2 in R
+
+```r
+library(DESeq2)
+dds <- DESeqDataSetFromMatrix(countData = round(counts), colData = meta, design = ~ batch + condition)
+dds$condition <- relevel(dds$condition, ref = "control")
+keep <- rowSums(counts(dds) >= 10) >= min(table(dds$condition))
+dds <- dds[keep, ]
+dds <- DESeq(dds)
+res <- results(dds, contrast = c("condition", "treated", "control"), alpha = 0.05)
+res_shr <- lfcShrink(dds, coef = "condition_treated_vs_control", type = "apeglm")
+vsd <- vst(dds, blind = FALSE)
+out <- as.data.frame(res_shr) |> tibble::rownames_to_column("gene") |> dplyr::arrange(padj)
+readr::write_csv(out, file.path(Sys.getenv("SCIENCE_ARTIFACT_DIR"), "de_results.csv"))
+```
+
+`apeglm` ships with DESeq2 on bioconda as a dependency; if `lfcShrink` complains, `type = "ashr"` needs `r-ashr`, and `type = "normal"` works with no extra package but over-shrinks large effects.
+
+## edgeR quasi-likelihood
+
+```r
+library(edgeR)
+dge <- DGEList(counts = counts, group = meta$condition)
+keep <- filterByExpr(dge, group = meta$condition)
+dge <- dge[keep, , keep.lib.sizes = FALSE]
+dge <- calcNormFactors(dge, method = "TMM")
+design <- model.matrix(~ batch + condition, data = meta)
+dge <- estimateDisp(dge, design)
+fit <- glmQLFit(dge, design)
+qlf <- glmQLFTest(fit, coef = "conditiontreated")
+tt <- topTags(qlf, n = Inf)$table   # logFC, logCPM, F, PValue, FDR
+```
+
+## limma-voom
+
+```r
+library(limma); library(edgeR)
+dge <- calcNormFactors(DGEList(counts[keep, ]))
+v <- voom(dge, design, plot = TRUE)          # keep the mean–variance plot as a QC artifact
+fit <- eBayes(lmFit(v, design))
+tt <- topTable(fit, coef = "conditiontreated", n = Inf, sort.by = "P")   # logFC, AveExpr, t, P.Value, adj.P.Val
+```
+
+With repeated measures on the same subject and a covariate you also want to test, use `duplicateCorrelation(v, design, block = meta$subject)` and pass `correlation =` to `lmFit`.
+
+## Interpreting and reporting
+
+- Thresholds: report the numbers at padj < 0.05 and |log2FC| ≥ 1, and also at padj < 0.05 alone; state which the figures use.
+- Shrunken LFC for ranking, plotting, and GSEA; unshrunk LFC only if the user specifically asks for raw estimates.
+- Independent filtering / Cook's outlier handling in DESeq2 sets `padj` to `NA` for some genes; do not drop those rows from the table silently — keep them and explain the `NA`.
+- If the PCA showed a batch axis and batch was not in the design (because it was unknown), say that the DE list may include batch-driven genes. `sva::svaseq` or RUVSeq are follow-ups, not silent fixes.

--- a/apps/desktop/resources/skills/bulk-rnaseq-analysis/references/enrichment.md
+++ b/apps/desktop/resources/skills/bulk-rnaseq-analysis/references/enrichment.md
@@ -1,0 +1,71 @@
+# Functional enrichment after differential expression
+
+## Two questions, two methods
+
+| Question | Method | Input | Background |
+|----------|--------|-------|------------|
+| "Is my significant gene list enriched for a pathway?" | ORA (hypergeometric / Fisher) | Significant up **or** down genes (separately) | **All genes that passed the low-count filter** |
+| "Does a pathway shift as a whole, even if few genes pass the threshold?" | GSEA (pre-ranked) | Every tested gene ranked by shrunken log2FC (or by `stat`) | None (uses the full ranking) |
+
+Using the whole genome as ORA background inflates significance for every pathway expressed in the tissue — a classic reviewer catch. Combining up- and down-regulated genes into one ORA list cancels directional signal.
+
+## Gene identifiers
+
+Enrichment libraries key on **HGNC symbols** (Enrichr, MSigDB) or **Entrez IDs** (clusterProfiler default). Convert before enriching, keep the mapping table, and report how many genes failed to map.
+
+- Python: `mygene.MyGeneInfo().querymany(ids, scopes="ensembl.gene", fields="symbol,entrezgene", species="human")`.
+- R: `clusterProfiler::bitr(ids, fromType="ENSEMBL", toType=c("SYMBOL","ENTREZID"), OrgDb=org.Hs.eg.db)`.
+- Ensembl versions (`ENSG00000141510.16`) must have the suffix stripped first: `ids.str.replace(r"\.\d+$", "", regex=True)`.
+
+## gseapy
+
+```python
+import gseapy as gp
+
+bg = res.index.tolist()                                   # all tested genes (symbols)
+up = res.query("padj < 0.05 and log2FoldChange >= 1").index.tolist()
+down = res.query("padj < 0.05 and log2FoldChange <= -1").index.tolist()
+
+ora_up = gp.enrichr(gene_list=up, gene_sets=["GO_Biological_Process_2023", "KEGG_2021_Human"],
+                    background=bg, outdir=None).results
+ora_up = ora_up.sort_values("Adjusted P-value")
+
+rnk = res["log2FoldChange"].dropna().sort_values(ascending=False)
+gsea = gp.prerank(rnk=rnk, gene_sets="MSigDB_Hallmark_2020", permutation_num=1000, seed=0,
+                  min_size=15, max_size=500, threads=4, outdir=None)
+gsea_res = gsea.res2d.sort_values("FDR q-val")             # Term, NES, NOM p-val, FDR q-val, Lead_genes
+```
+
+Offline: pass a local `.gmt` path as `gene_sets=`. Mouse: use `_Mouse` library variants or an organism-specific GMT and mouse symbols (capitalized, e.g. `Trp53`).
+
+Dot plot of the top terms (matplotlib, so it stays editable in the viewer):
+
+```python
+top = ora_up.head(15).iloc[::-1]
+top["ratio"] = top["Overlap"].str.split("/").map(lambda x: int(x[0]) / int(x[1]))
+fig, ax = plt.subplots(figsize=(7, 5.5))
+sc = ax.scatter(top["ratio"], top["Term"], s=top["Overlap"].str.split("/").str[0].astype(int) * 8,
+                c=-np.log10(top["Adjusted P-value"]), cmap="viridis")
+fig.colorbar(sc, label="−log10 adjusted p")
+ax.set_xlabel("Gene ratio"); ax.set_title("GO BP — up-regulated genes (ORA)")
+fig.tight_layout(); fig.savefig(f"{SCIENCE_ARTIFACT_DIR}/enrich_up_dotplot.png", dpi=150)
+```
+
+## clusterProfiler (macOS, via bioconda)
+
+```r
+library(clusterProfiler); library(org.Hs.eg.db)
+ego <- enrichGO(gene = up_entrez, universe = bg_entrez, OrgDb = org.Hs.eg.db, ont = "BP",
+                pAdjustMethod = "BH", qvalueCutoff = 0.05, readable = TRUE)
+ekegg <- enrichKEGG(gene = up_entrez, universe = bg_entrez, organism = "hsa")   # needs network
+geneList <- sort(setNames(res$log2FoldChange, res$entrez), decreasing = TRUE)
+gse <- gseGO(geneList, OrgDb = org.Hs.eg.db, ont = "BP", seed = TRUE, eps = 0)
+p <- dotplot(ego, showCategory = 15) + ggtitle("GO BP — up-regulated (ORA)")
+ggsave(file.path(Sys.getenv("SCIENCE_ARTIFACT_DIR"), "enrich_up_dotplot.png"), p, width = 7, height = 5.5, dpi = 150)
+```
+
+`simplify(ego)` collapses redundant GO terms (semantic similarity > 0.7) — useful before plotting, and say it was applied.
+
+## Reporting
+
+For each enrichment: method, library and version/date, background size, gene-list size and how many mapped, correction method, top terms with adjusted p and gene ratio (ORA) or NES and FDR (GSEA), and a sentence on whether the terms are consistent with the experimental expectation. An enrichment of "ribosome" or "mitochondrial translation" in a treatment contrast is often a proliferation or quality artefact — flag it rather than narrating it as biology.

--- a/apps/desktop/resources/skills/bulk-rnaseq-analysis/scripts/count_qc.py
+++ b/apps/desktop/resources/skills/bulk-rnaseq-analysis/scripts/count_qc.py
@@ -1,0 +1,116 @@
+"""Count-matrix QC figures for bulk RNA-seq.
+
+Usage inside run_python (the kernel already has pandas/matplotlib/seaborn):
+
+    exec(open(f"{SKILL_DIR}/scripts/count_qc.py").read())   # or paste the file
+    counts = pd.read_csv(".../counts.csv", index_col=0)      # genes x samples
+    meta   = pd.read_csv(".../metadata.csv", index_col=0)    # samples x covariates
+    qc = count_qc(counts, meta, color="condition", shape="batch", outdir=SCIENCE_ARTIFACT_DIR)
+    # qc["figures"] lists the PNG paths to declare in raster_artifacts.
+
+Every function returns plain pandas objects; nothing here writes outside `outdir`.
+"""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+
+def log_cpm(counts: pd.DataFrame, prior: float = 1.0) -> pd.DataFrame:
+    """log2(CPM + prior). Plotting-only transform; never feed it to a DE model."""
+    lib = counts.sum(axis=0)
+    return np.log2(counts.div(lib, axis=1) * 1e6 + prior)
+
+
+def filter_by_expr(counts: pd.DataFrame, group: pd.Series, min_count: int = 10) -> pd.Series:
+    """edgeR-style low-count filter: keep genes with >= min_count in at least
+    (smallest group size) samples. Returns a boolean mask over genes."""
+    smallest = int(group.value_counts().min())
+    return (counts >= min_count).sum(axis=1) >= smallest
+
+
+def count_qc(
+    counts: pd.DataFrame,
+    meta: pd.DataFrame,
+    color: str,
+    shape: Optional[str] = None,
+    outdir: str = ".",
+    n_top_var: int = 2000,
+) -> dict:
+    """Library-size bars, zero fraction, sample correlation heatmap, PCA.
+
+    Returns {"figures": [paths], "pca": DataFrame, "library_size": Series}.
+    """
+    os.makedirs(outdir, exist_ok=True)
+    counts = counts.loc[:, meta.index]  # enforce sample order == metadata order
+    figures = []
+
+    lib = counts.sum(axis=0)
+    zero_frac = (counts == 0).mean(axis=0)
+
+    # 1. library size + zero fraction -------------------------------------
+    fig, axes = plt.subplots(1, 2, figsize=(11, 4))
+    order = lib.sort_values().index
+    axes[0].barh(order, lib[order] / 1e6, color=sns.color_palette("deep")[0])
+    axes[0].set_xlabel("Library size (millions of counts)")
+    axes[0].set_title("Library size per sample")
+    axes[1].barh(order, zero_frac[order], color=sns.color_palette("deep")[1])
+    axes[1].set_xlabel("Fraction of genes with zero counts")
+    axes[1].set_title("Zero fraction per sample")
+    fig.tight_layout()
+    p = os.path.join(outdir, "qc_library_size.png")
+    fig.savefig(p, dpi=150)
+    plt.close(fig)
+    figures.append(p)
+
+    # 2. sample-sample correlation -----------------------------------------
+    lc = log_cpm(counts)
+    corr = lc.corr(method="spearman")
+    annot = meta[[c for c in [color, shape] if c]].copy()
+    lut = {}
+    row_colors = pd.DataFrame(index=annot.index)
+    for col in annot.columns:
+        levels = annot[col].astype(str).unique()
+        pal = dict(zip(levels, sns.color_palette("Set2", len(levels))))
+        lut[col] = pal
+        row_colors[col] = annot[col].astype(str).map(pal)
+    g = sns.clustermap(corr, cmap="viridis", row_colors=row_colors, col_colors=row_colors,
+                       figsize=(8, 8), cbar_kws={"label": "Spearman r (log2 CPM)"})
+    g.fig.suptitle("Sample–sample correlation", y=1.02)
+    p = os.path.join(outdir, "qc_sample_correlation.png")
+    g.savefig(p, dpi=150)
+    plt.close(g.fig)
+    figures.append(p)
+
+    # 3. PCA on top-variance genes -----------------------------------------
+    top = lc.var(axis=1).sort_values(ascending=False).head(n_top_var).index
+    x = lc.loc[top].T
+    x = x - x.mean(axis=0)
+    u, s, vt = np.linalg.svd(x.values, full_matrices=False)
+    var_exp = s ** 2 / (s ** 2).sum()
+    pcs = pd.DataFrame(u[:, :4] * s[:4], index=x.index, columns=[f"PC{i+1}" for i in range(4)])
+    pcs = pcs.join(meta)
+
+    fig, ax = plt.subplots(figsize=(6.5, 5.5))
+    sns.scatterplot(data=pcs, x="PC1", y="PC2", hue=color, style=shape, s=110, ax=ax, edgecolor="black")
+    for name, row in pcs.iterrows():
+        ax.annotate(str(name), (row["PC1"], row["PC2"]), fontsize=7, xytext=(4, 4), textcoords="offset points")
+    ax.set_xlabel(f"PC1 ({var_exp[0]*100:.1f}%)")
+    ax.set_ylabel(f"PC2 ({var_exp[1]*100:.1f}%)")
+    ax.set_title(f"PCA on top {len(top)} variable genes (log2 CPM)")
+    ax.axhline(0, lw=0.5, color="grey"); ax.axvline(0, lw=0.5, color="grey")
+    fig.tight_layout()
+    p = os.path.join(outdir, "qc_pca.png")
+    fig.savefig(p, dpi=150)
+    plt.close(fig)
+    figures.append(p)
+
+    return {"figures": figures, "pca": pcs, "library_size": lib, "zero_fraction": zero_frac,
+            "variance_explained": pd.Series(var_exp[:4], index=pcs.columns[:4])}

--- a/apps/desktop/resources/skills/bulk-rnaseq-analysis/scripts/count_qc.py
+++ b/apps/desktop/resources/skills/bulk-rnaseq-analysis/scripts/count_qc.py
@@ -94,16 +94,26 @@ def count_qc(
     x = lc.loc[top].T
     x = x - x.mean(axis=0)
     u, s, vt = np.linalg.svd(x.values, full_matrices=False)
-    var_exp = s ** 2 / (s ** 2).sum()
-    pcs = pd.DataFrame(u[:, :4] * s[:4], index=x.index, columns=[f"PC{i+1}" for i in range(4)])
+    var_sum = (s ** 2).sum()
+    var_exp = s ** 2 / var_sum if var_sum > 0 else np.zeros_like(s)
+    n_pcs = min(4, len(s))
+    pc_cols = [f"PC{i+1}" for i in range(n_pcs)]
+    pcs = pd.DataFrame(u[:, :n_pcs] * s[:n_pcs], index=x.index, columns=pc_cols)
     pcs = pcs.join(meta)
 
     fig, ax = plt.subplots(figsize=(6.5, 5.5))
-    sns.scatterplot(data=pcs, x="PC1", y="PC2", hue=color, style=shape, s=110, ax=ax, edgecolor="black")
-    for name, row in pcs.iterrows():
-        ax.annotate(str(name), (row["PC1"], row["PC2"]), fontsize=7, xytext=(4, 4), textcoords="offset points")
-    ax.set_xlabel(f"PC1 ({var_exp[0]*100:.1f}%)")
-    ax.set_ylabel(f"PC2 ({var_exp[1]*100:.1f}%)")
+    if n_pcs >= 2:
+        sns.scatterplot(data=pcs, x="PC1", y="PC2", hue=color, style=shape, s=110, ax=ax, edgecolor="black")
+        for name, row in pcs.iterrows():
+            ax.annotate(str(name), (row["PC1"], row["PC2"]), fontsize=7, xytext=(4, 4), textcoords="offset points")
+        ax.set_xlabel(f"PC1 ({var_exp[0]*100:.1f}%)")
+        ax.set_ylabel(f"PC2 ({var_exp[1]*100:.1f}%)")
+    elif n_pcs == 1:
+        sns.scatterplot(data=pcs, x="PC1", y=np.zeros(len(pcs)), hue=color, style=shape, s=110, ax=ax, edgecolor="black")
+        for name, row in pcs.iterrows():
+            ax.annotate(str(name), (row["PC1"], 0), fontsize=7, xytext=(4, 4), textcoords="offset points")
+        ax.set_xlabel(f"PC1 ({var_exp[0]*100:.1f}%)" if len(var_exp) > 0 else "PC1")
+        ax.set_ylabel("")
     ax.set_title(f"PCA on top {len(top)} variable genes (log2 CPM)")
     ax.axhline(0, lw=0.5, color="grey"); ax.axvline(0, lw=0.5, color="grey")
     fig.tight_layout()
@@ -113,4 +123,4 @@ def count_qc(
     figures.append(p)
 
     return {"figures": figures, "pca": pcs, "library_size": lib, "zero_fraction": zero_frac,
-            "variance_explained": pd.Series(var_exp[:4], index=pcs.columns[:4])}
+            "variance_explained": pd.Series(var_exp[:n_pcs], index=pcs.columns[:n_pcs])}

--- a/apps/desktop/resources/skills/ecology-and-diversity/SKILL.md
+++ b/apps/desktop/resources/skills/ecology-and-diversity/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: ecology-and-diversity
+description: "Community ecology and microbiome diversity analysis with vegan (R, shipped) or scikit-bio/scipy (Python) — species/OTU/ASV abundance tables, rarefaction and coverage, alpha diversity (richness, Shannon, Simpson, Chao1, Faith's PD) with group comparisons, beta diversity (Bray–Curtis, Jaccard, UniFrac) with PCoA/NMDS ordination, PERMANOVA (adonis2) and dispersion tests (betadisper), indicator/differentially abundant taxa (ANCOM-BC, ALDEx2, or CLR + Wilcoxon), constrained ordination (RDA/CCA/dbRDA) against environmental variables, Mantel tests, species accumulation curves, and stacked taxonomic bar plots. Use whenever a user has samples × taxa counts, a QIIME2/DADA2/mothur/Kraken output, an environmental matrix, or asks about diversity, community composition, or which taxa differ between habitats/treatments. Trigger terms: 多样性、α 多样性、β 多样性、Shannon、Simpson、Chao1、稀释曲线、群落结构、NMDS、PCoA、PERMANOVA、adonis、Bray-Curtis、UniFrac、微生物组、16S、OTU、ASV、物种丰度、RDA、CCA、指示种、物种累积曲线."
+license: MIT license
+metadata:
+  version: "1.0"
+  skill-author: PaperMachine community
+---
+
+# Ecology and Diversity Analysis
+
+Analyze community abundance tables through `run_r` (vegan is the reference implementation; use it by default) or `run_python` (scipy/scikit-bio) and write ordinations, diversity tables, and taxon bar plots to `SCIENCE_ARTIFACT_DIR`. The reviewer's checklist: sampling depth was handled explicitly (rarefaction or a depth-aware method) and the decision is stated; alpha and beta diversity use named indices and distances; PERMANOVA is accompanied by a dispersion test because a significant `adonis2` can mean different spread, not different centroids; and differential-abundance claims are made with a compositionally aware method or clearly labelled exploratory.
+
+## Installation
+
+Shipped: `r-vegan`, `r-ape` (PCoA, phylogenetic distances), `r-phangorn`, `r-pheatmap`, `r-ggpubr`, `r-rstatix`; Python `scipy`, `scikit-learn`, `scikit-posthocs`. Optional through `install_science_packages`:
+
+| Need | Language | Spec |
+|------|----------|------|
+| phyloseq object workflow (import QIIME2/BIOM, tree, taxonomy) | r | `bioconductor-phyloseq` (macOS) |
+| Differential abundance (compositional) | r | `bioconductor-ancombc`, `bioconductor-aldex2` (macOS); python: `scikit-bio` (ANCOM, conda-forge) |
+| Indicator species | r | `r-indicspecies` (conda-forge) |
+| UniFrac and Faith's PD | python | `scikit-bio`; r: `r-picante` (conda-forge, Faith's PD) or `bioconductor-phyloseq` (UniFrac, macOS) |
+| Rarefaction with coverage (iNEXT) | r | `r-inext` (conda-forge) |
+| Zero-replacement for CLR | r | `r-zcompositions` |
+| Microbiome-specific plots | r | `bioconductor-microbiome` (macOS) |
+
+Compatibility traps: vegan expects **samples as rows, taxa as columns** — transpose QIIME/DADA2 output (`t(otu)`). Use `adonis2(dist ~ group, data = meta, permutations = 999, by = "margin")` with `set.seed(1)`. On Bray–Curtis matrices with many zeros, `metaMDS` may need `try = 20, trymax = 100`. `rarefy`/`rrarefy` need integer counts. `diversity(x, "simpson")` returns Gini–Simpson (1 − D); `"invsimpson"` returns 1/D. UniFrac needs a rooted tree matching taxa columns.
+
+## Workflow
+
+1. **Orient data.** Samples × taxa integer table, sample metadata, optional taxonomy and phylogenetic tree. Print library sizes (min/median/max), per-taxon prevalence, and singleton fraction. Remove unassigned taxa, mitochondria/chloroplast, and low-depth samples (plateau depth or ≥ 1,000 reads). Record removals.
+2. **Rarefaction & depth.** Draw rarefaction curves (`vegan::rarecurve`); save `rarefaction_curves.png`. State strategy: rarefy once with seed (`rrarefy(x, sample = d)`), use `avgdist` (repeated rarefaction, preferred for beta diversity), or use depth-aware methods (CLR/ANCOM-BC). Report Good's coverage (`1 − singletons / reads`).
+3. **Alpha diversity.** Per sample: observed richness (`specnumber`), Chao1 (`estimateR`), Shannon (`diversity`), Gini–Simpson, Pielou's evenness (`H / log(S)`), Faith's PD with tree. Export `alpha_diversity.csv`. Compare across groups via Kruskal–Wallis + Dunn (BH) or ANOVA; plot boxplots with points (`ggpubr::ggboxplot(add = "jitter")`). Use `lme4::lmer` for nested/repeated designs.
+4. **Beta diversity.** Distance: Bray–Curtis (abundance), Jaccard (presence/absence), Aitchison (Euclidean on CLR), weighted/unweighted UniFrac. Ordination: PCoA (`ape::pcoa`, report % variance of axes 1–2) or NMDS (`metaMDS(k = 2)`, report stress). Plot with 95% ellipses (`stat_ellipse`) and `envfit` vectors (p < 0.05). `scripts/community_analysis.R::beta_diversity()` runs full pipeline in one call.
+5. **Test community differences.** `adonis2(dist ~ group, data = meta, permutations = 999)` for pseudo-F, R², p; **always** run `betadisper` + `permutest` for dispersion homogeneity. Pairwise PERMANOVA for > 2 groups with BH. For nested designs, restrict permutations (`how(blocks = meta$site)`). For environmental gradients, run dbRDA (`capscale`) or Mantel tests (`mantel`).
+6. **Composition & taxa.** Aggregate to phylum/genus, plot top 10–15 taxa stacked bars (`geom_col(position = "fill")`) and top 30 taxa heatmap (`pheatmap` on log10 relative abundance). Differential abundance: ANCOM-BC2/ALDEx2 when installed; otherwise CLR + Wilcoxon/Kruskal (BH), labelled *exploratory*. Report effect sizes, not just q-values.
+7. **Deliver.** `alpha_diversity.csv`, `beta_diversity_tests.csv`, `ordination_scores.csv`, `differential_taxa.csv`, `top_taxa_relative_abundance.csv`; figures: rarefaction, alpha boxplots, ordination, stacked bars, heatmap; `annotate_artifact` ordination with distance, method, stress/variance, R² and p.
+
+## Integrity rules
+
+1. **State the depth decision** (rarefied to N with seed / not rarefied and why) and report Good's coverage.
+2. **Every PERMANOVA is reported with its dispersion test**; a significant betadisper means "composition or spread differs" — say so.
+3. **NMDS without stress, PCoA without % variance, are not reportable.**
+4. **Distances and indices are named precisely** (Bray–Curtis on relative abundance; Shannon, ln base; Gini–Simpson).
+5. **Relative-abundance t-tests are not differential-abundance evidence.** Use a compositional method or label results exploratory.
+6. **Pseudoreplication**: multiple samples from one site/animal/plot are not independent — block or nest them.
+7. **Do not drop rare taxa before alpha diversity** (richness estimators need singletons); filtering by prevalence is for differential abundance only, and its threshold is reported.
+8. **Seeds** before rarefaction, NMDS, and permutation tests; print `packageVersion("vegan")`.
+
+## Quick reference (vegan)
+
+```r
+library(vegan); set.seed(1)
+otu <- t(as.matrix(counts))                      # samples x taxa
+depth <- min(rowSums(otu)); rar <- rrarefy(otu, depth)
+alpha <- data.frame(S = specnumber(rar), shannon = diversity(rar, "shannon"), invsimpson = diversity(rar, "invsimpson"),
+                    chao1 = t(estimateR(rar))[, "S.chao1"]); alpha$evenness <- alpha$shannon / log(alpha$S)
+bc <- vegdist(decostand(rar, "total"), method = "bray")   # or avgdist(otu, sample = depth, iterations = 100)
+pc <- ape::pcoa(bc); pc$values$Relative_eig[1:2]
+nm <- metaMDS(bc, k = 2, try = 20, trymax = 100); nm$stress
+adonis2(bc ~ group, data = meta, permutations = 999)
+permutest(betadisper(bc, meta$group), permutations = 999)
+ef <- envfit(nm, meta[, c("pH", "temperature")], permutations = 999); ef
+rda_fit <- capscale(bc ~ pH + temperature, data = meta); anova(rda_fit, by = "margin", permutations = 999)
+```
+
+Files: `scripts/community_analysis.R` (`alpha_table`, `beta_diversity`, `pairwise_permanova`, `top_taxa_bars`), `references/methods_notes.md` (choosing distances and transformations, rarefaction debate, compositional data, reporting template).

--- a/apps/desktop/resources/skills/ecology-and-diversity/references/methods_notes.md
+++ b/apps/desktop/resources/skills/ecology-and-diversity/references/methods_notes.md
@@ -1,0 +1,54 @@
+# Methods notes: distances, transformations, rarefaction, compositional data, reporting
+
+## Choosing a distance
+
+| Question | Distance | Input |
+|----------|----------|-------|
+| Do abundant taxa differ? | Bray–Curtis | relative or rarefied counts |
+| Does membership differ (rare taxa matter)? | Jaccard (binary) | presence/absence |
+| Do phylogenetically related lineages differ? | Weighted UniFrac (abundance) / unweighted UniFrac (membership) | counts + rooted tree |
+| Compositional, want a Euclidean geometry (PCA, linear models) | Aitchison = Euclidean on CLR | counts + zero replacement |
+| Environmental / continuous variables between sites | Euclidean on standardized variables (`decostand(env, "standardize")`) | env matrix |
+
+Show at least two (one abundance-weighted, one presence/absence); concordant conclusions are stronger, discordant ones are informative (rare vs dominant taxa drive the difference).
+
+## Transformations before ordination
+
+- `decostand(x, "total")` — relative abundance; pairs with Bray–Curtis.
+- `decostand(x, "hellinger")` — square-root of relative abundance; the standard input for **RDA/PCA** on abundance data (Legendre & Gallagher 2001), down-weights dominant taxa.
+- `log1p` or `decostand(x, "log")` — compresses dominance; state the base.
+- CLR: `log(x + pseudocount) − mean(log(x + pseudocount))` per sample; pseudocount = 0.5 or `zCompositions::cmultRepl(x, method = "CZM")`.
+- Wisconsin double standardization (`wisconsin`) — `metaMDS` applies it automatically to raw counts when `autotransform = TRUE`; pass a distance matrix to avoid surprises.
+
+## Rarefaction: the honest position
+
+Rarefying discards data and adds sampling noise (McMurdie & Holmes 2014), but it is the simplest way to make richness comparable across samples with very unequal depth and remains standard for alpha diversity and UniFrac. Practical rule: **alpha diversity and presence/absence metrics** — rarefy (once with a seed, or average over repeats); **abundance-weighted beta diversity** — `avgdist` (repeated rarefaction) or relative abundance; **differential abundance** — never rarefy, use a model that handles depth (ANCOM-BC, ALDEx2, DESeq2-with-caveats). Whatever you choose, state the depth, how many samples were dropped, and Good's coverage.
+
+## Compositional data in one paragraph
+
+Sequencing counts are constrained by depth: an increase in one taxon's relative abundance forces others down. Correlations and t-tests on relative abundances therefore produce spurious associations. Log-ratio methods (CLR, ALR, ILR; ANCOM-BC's bias correction; ALDEx2's Monte-Carlo Dirichlet instances) address this. Report differential abundance as log fold change with CI or CLR difference, and disclose the method's reference frame and the prevalence filter.
+
+## PERMANOVA and dispersion
+
+`adonis2` tests whether group centroids differ **in the multivariate space of the chosen distance**, but is sensitive to unequal dispersion, especially with unbalanced groups. `betadisper` + `permutest` tests dispersion homogeneity. Report both; interpret a significant PERMANOVA with a significant dispersion test as "communities differ in location and/or spread". R² is the effect size — an R² of 0.03 with p = 0.001 is a tiny effect detectable because n is large.
+
+For nested designs use restricted permutations: `how(blocks = meta$site, nperm = 999)` or `plots = Plots(strata = meta$site, type = "free")`. For repeated measures on the same individual, permute within individual.
+
+## Ordination choices
+
+- **PCoA** — metric, preserves the distance as well as possible in few axes; report % variance of the plotted axes and whether negative eigenvalues required a correction.
+- **NMDS** — rank-based, robust to non-linearity; report stress (and the Shepard plot when stress > 0.15) and that it converged. Axes have no % variance.
+- **RDA / dbRDA / CCA** — constrained by environmental variables; report the proportion of constrained variance, the global permutation test, and per-term marginal tests (`anova.cca(by = "margin")`). Check collinearity (`vif.cca` < 10) and use forward selection (`ordiR2step`) only with an adjusted R² stopping rule.
+
+## Alpha diversity indices, precisely
+
+- Observed richness S; Chao1 (needs singletons and doubletons; undefined without them); ACE.
+- Shannon H′ = −Σ p ln p (natural log unless stated; "effective number of species" = exp(H′)).
+- Simpson: D = Σ p²; Gini–Simpson 1 − D; inverse Simpson 1/D (Hill number of order 2). Say which.
+- Pielou J = H′ / ln S.
+- Faith's PD: sum of branch lengths spanning the sample's taxa (needs a rooted tree).
+- Hill numbers (q = 0, 1, 2) give a unified profile: `vegan::renyi(x, hill = TRUE)` or `iNEXT`.
+
+## Reporting template
+
+> After removing chloroplast/mitochondrial ASVs and samples with < 1,000 reads (n = 2 removed), samples were rarefied to 8,412 reads (seed 1; Good's coverage ≥ 0.98). Alpha diversity (Shannon, ln) differed among treatments (Kruskal–Wallis H = …, p = …; Dunn's test, BH-adjusted: A vs B p = …). Community composition (Bray–Curtis on relative abundance) differed by treatment (PERMANOVA, 999 permutations, pseudo-F = …, R² = 0.18, p = 0.001) with homogeneous dispersions (betadisper p = 0.41); NMDS stress = 0.12. Genus-level differential abundance (ANCOM-BC2, prevalence ≥ 10 %) identified … taxa (|log FC| > 1, q < 0.05). Analyses used vegan v…

--- a/apps/desktop/resources/skills/ecology-and-diversity/scripts/community_analysis.R
+++ b/apps/desktop/resources/skills/ecology-and-diversity/scripts/community_analysis.R
@@ -1,0 +1,101 @@
+# Community diversity helpers around vegan / ape. Samples are rows, taxa are columns throughout.
+#
+#   source(file.path(SKILL_DIR, "scripts/community_analysis.R"))
+#   alpha <- alpha_table(otu, meta, group = "treatment", depth = NULL)      # rarefies to min depth when depth is NULL
+#   beta  <- beta_diversity(otu, meta, group = "treatment", method = "bray", out_dir = Sys.getenv("SCIENCE_ARTIFACT_DIR"))
+#   beta$permanova ; beta$dispersion ; beta$pairwise ; beta$figures        # declare beta$figures in raster_artifacts
+#   bars  <- top_taxa_bars(otu, meta, taxonomy, rank = "Genus", group = "treatment", top_n = 12, out_dir = ...)
+
+suppressPackageStartupMessages({ library(vegan); library(ape); library(ggplot2); library(dplyr); library(tidyr) })
+
+alpha_table <- function(otu, meta, group, depth = NULL, seed = 1) {
+  set.seed(seed)
+  otu <- as.matrix(otu); storage.mode(otu) <- "integer"
+  stopifnot(all(rownames(otu) %in% rownames(meta)))
+  meta <- meta[rownames(otu), , drop = FALSE]
+  d <- if (is.null(depth)) min(rowSums(otu)) else depth
+  keep <- rowSums(otu) >= d
+  rar <- rrarefy(otu[keep, ], sample = d)
+  est <- t(estimateR(rar))
+  out <- data.frame(
+    sample = rownames(rar), group = meta[rownames(rar), group],
+    reads_raw = rowSums(otu[keep, ]), depth_used = d,
+    goods_coverage = 1 - rowSums(otu[keep, ] == 1) / rowSums(otu[keep, ]),
+    observed = specnumber(rar), chao1 = est[, "S.chao1"], chao1_se = est[, "se.chao1"],
+    shannon_ln = diversity(rar, "shannon"), gini_simpson = diversity(rar, "simpson"),
+    inv_simpson = diversity(rar, "invsimpson"), row.names = NULL)
+  out$pielou_evenness <- out$shannon_ln / log(out$observed)
+  attr(out, "dropped_samples") <- rownames(otu)[!keep]
+  out
+}
+
+pairwise_permanova <- function(dist, groups, permutations = 999, p_adjust = "BH") {
+  groups <- as.factor(groups); lv <- levels(groups); res <- list()
+  for (i in seq_len(length(lv) - 1)) for (j in (i + 1):length(lv)) {
+    sel <- groups %in% c(lv[i], lv[j])
+    dm <- as.dist(as.matrix(dist)[sel, sel])
+    a <- adonis2(dm ~ g, data = data.frame(g = droplevels(groups[sel])), permutations = permutations)
+    res[[length(res) + 1]] <- data.frame(pair = paste(lv[i], "vs", lv[j]), F = a$F[1], R2 = a$R2[1], p = a$`Pr(>F)`[1])
+  }
+  out <- bind_rows(res); out$p_adj <- p.adjust(out$p, p_adjust); out
+}
+
+beta_diversity <- function(otu, meta, group, method = "bray", transform = c("total", "hellinger", "none"),
+                           rarefy_to = NULL, out_dir = ".", seed = 1, permutations = 999, prefix = "beta") {
+  transform <- match.arg(transform); set.seed(seed)
+  dir.create(out_dir, showWarnings = FALSE, recursive = TRUE)
+  otu <- as.matrix(otu); meta <- meta[rownames(otu), , drop = FALSE]
+  if (!is.null(rarefy_to)) { keep <- rowSums(otu) >= rarefy_to; otu <- rrarefy(otu[keep, ], rarefy_to); meta <- meta[rownames(otu), , drop = FALSE] }
+  x <- if (transform == "none") otu else decostand(otu, transform)
+  dist <- vegdist(x, method = method, binary = method == "jaccard")
+  g <- factor(meta[[group]])
+
+  pc <- pcoa(dist, correction = "cailliez")
+  eig <- pc$values; rel <- if ("Rel_corr_eig" %in% names(eig)) eig$Rel_corr_eig else eig$Relative_eig
+  scores_pc <- data.frame(sample = rownames(pc$vectors), PCo1 = pc$vectors[, 1], PCo2 = pc$vectors[, 2], group = g)
+  nm <- metaMDS(dist, k = 2, try = 20, trymax = 100, trace = 0)
+  scores_nm <- data.frame(sample = rownames(nm$points), NMDS1 = nm$points[, 1], NMDS2 = nm$points[, 2], group = g)
+
+  perm <- adonis2(dist ~ g, data = data.frame(g = g), permutations = permutations)
+  bd <- betadisper(dist, g); bd_test <- permutest(bd, permutations = permutations)
+  pw <- if (nlevels(g) > 2) pairwise_permanova(dist, g, permutations) else NULL
+
+  figs <- character()
+  p1 <- ggplot(scores_pc, aes(PCo1, PCo2, colour = group)) + geom_point(size = 2.6) + stat_ellipse(level = 0.95) +
+    labs(x = sprintf("PCo1 (%.1f%%)", 100 * rel[1]), y = sprintf("PCo2 (%.1f%%)", 100 * rel[2]),
+         title = sprintf("PCoA — %s distance", method),
+         subtitle = sprintf("PERMANOVA R² = %.3f, p = %.3f; dispersion p = %.3f", perm$R2[1], perm$`Pr(>F)`[1], bd_test$tab$`Pr(>F)`[1])) +
+    theme_bw()
+  f1 <- file.path(out_dir, paste0(prefix, "_pcoa.png")); ggsave(f1, p1, width = 6.5, height = 5, dpi = 150); figs <- c(figs, f1)
+  p2 <- ggplot(scores_nm, aes(NMDS1, NMDS2, colour = group)) + geom_point(size = 2.6) + stat_ellipse(level = 0.95) +
+    labs(title = sprintf("NMDS — %s distance", method), subtitle = sprintf("stress = %.3f (k = 2)%s", nm$stress, if (nm$converged) "" else ", NOT converged")) + theme_bw()
+  f2 <- file.path(out_dir, paste0(prefix, "_nmds.png")); ggsave(f2, p2, width = 6.5, height = 5, dpi = 150); figs <- c(figs, f2)
+
+  tests <- bind_rows(
+    data.frame(test = "PERMANOVA (adonis2)", term = group, statistic = perm$F[1], R2 = perm$R2[1], p = perm$`Pr(>F)`[1]),
+    data.frame(test = "betadisper permutest", term = group, statistic = bd_test$tab$F[1], R2 = NA, p = bd_test$tab$`Pr(>F)`[1]))
+  write.csv(tests, file.path(out_dir, paste0(prefix, "_tests.csv")), row.names = FALSE)
+  if (!is.null(pw)) write.csv(pw, file.path(out_dir, paste0(prefix, "_pairwise_permanova.csv")), row.names = FALSE)
+  write.csv(full_join(scores_pc, scores_nm, by = c("sample", "group")), file.path(out_dir, paste0(prefix, "_ordination_scores.csv")), row.names = FALSE)
+
+  list(dist = dist, pcoa = pc, nmds = nm, permanova = perm, dispersion = bd_test, pairwise = pw,
+       scores = list(pcoa = scores_pc, nmds = scores_nm), figures = figs, tests = tests)
+}
+
+top_taxa_bars <- function(otu, meta, taxonomy, rank = "Genus", group, top_n = 12, out_dir = ".", prefix = "composition") {
+  otu <- as.matrix(otu); rel <- otu / rowSums(otu)
+  tax <- as.character(taxonomy[colnames(otu), rank]); tax[is.na(tax) | tax == ""] <- "Unclassified"
+  agg <- t(rowsum(t(rel), tax))                                  # samples x rank levels
+  top <- names(sort(colMeans(agg), decreasing = TRUE))[seq_len(min(top_n, ncol(agg)))]
+  other <- rowSums(agg[, !colnames(agg) %in% top, drop = FALSE])
+  df <- as.data.frame(agg[, top, drop = FALSE]); df$Other <- other; df$sample <- rownames(df); df$group <- meta[rownames(df), group]
+  long <- pivot_longer(df, -c(sample, group), names_to = rank, values_to = "rel_abundance")
+  long[[rank]] <- factor(long[[rank]], levels = c(top, "Other"))
+  p <- ggplot(long, aes(sample, rel_abundance, fill = .data[[rank]])) + geom_col(width = 0.9) +
+    facet_grid(~ group, scales = "free_x", space = "free_x") +
+    scale_y_continuous(labels = scales::percent) + labs(y = "Relative abundance", x = NULL, title = sprintf("Top %d %s", top_n, rank)) +
+    theme_bw() + theme(axis.text.x = element_text(angle = 90, vjust = 0.5, hjust = 1, size = 7))
+  f <- file.path(out_dir, paste0(prefix, "_", tolower(rank), "_bars.png")); ggsave(f, p, width = 10, height = 5.5, dpi = 150)
+  write.csv(long, file.path(out_dir, paste0(prefix, "_", tolower(rank), "_relative_abundance.csv")), row.names = FALSE)
+  list(figure = f, table = long)
+}

--- a/apps/desktop/resources/skills/ecology-and-diversity/scripts/community_analysis.R
+++ b/apps/desktop/resources/skills/ecology-and-diversity/scripts/community_analysis.R
@@ -6,7 +6,7 @@
 #   beta$permanova ; beta$dispersion ; beta$pairwise ; beta$figures        # declare beta$figures in raster_artifacts
 #   bars  <- top_taxa_bars(otu, meta, taxonomy, rank = "Genus", group = "treatment", top_n = 12, out_dir = ...)
 
-suppressPackageStartupMessages({ library(vegan); library(ape); library(ggplot2); library(dplyr); library(tidyr) })
+suppressPackageStartupMessages({ library(vegan); library(ape); library(ggplot2); library(dplyr); library(tidyr); library(scales) })
 
 alpha_table <- function(otu, meta, group, depth = NULL, seed = 1) {
   set.seed(seed)
@@ -24,7 +24,7 @@ alpha_table <- function(otu, meta, group, depth = NULL, seed = 1) {
     observed = specnumber(rar), chao1 = est[, "S.chao1"], chao1_se = est[, "se.chao1"],
     shannon_ln = diversity(rar, "shannon"), gini_simpson = diversity(rar, "simpson"),
     inv_simpson = diversity(rar, "invsimpson"), row.names = NULL)
-  out$pielou_evenness <- out$shannon_ln / log(out$observed)
+  out$pielou_evenness <- ifelse(out$observed > 1, out$shannon_ln / log(out$observed), 0)
   attr(out, "dropped_samples") <- rownames(otu)[!keep]
   out
 }

--- a/apps/desktop/resources/skills/sequence-analysis/SKILL.md
+++ b/apps/desktop/resources/skills/sequence-analysis/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: sequence-analysis
+description: "DNA/RNA/protein sequence work with Biopython (Python, shipped) and ape/phangorn (R, shipped) — FASTA/FASTQ/GenBank parsing, GC content and sliding windows, transcription/translation, ORF finding, reverse complement, restriction sites, primer property checks, motif search, pairwise and multiple alignment, identity/similarity, codon usage, protein physicochemical properties, distance-based and maximum-likelihood phylogenetic trees with bootstrap, and tree plotting. Use whenever a user shares a sequence, a FASTA/GenBank file, an alignment, or asks about primers, ORFs, mutations, conservation, or a phylogeny. Trigger terms: 序列、FASTA、GenBank、比对、引物、翻译、ORF、GC 含量、酶切位点、突变、保守性、系统发育树、进化树、Biopython."
+license: MIT license
+metadata:
+  version: "1.0"
+  skill-author: PaperMachine community
+---
+
+# Sequence Analysis
+
+Handle sequence files and questions through `run_python` (Biopython) and `run_r` (ape, phangorn), writing tables and figures to `SCIENCE_ARTIFACT_DIR`. The workspace is read-only for the model — sequences arrive via `SCIENCE_WORKSPACE_DIR` paths or pasted text — and there is no shell, so external aligners (BLAST, MAFFT, MUSCLE) are not available unless installed as conda packages and driven through `subprocess` **from inside the kernel**. Prefer pure-Python/R methods first; reach for external binaries only for multiple alignment of many sequences, and say when a result would normally come from BLAST against a live database.
+
+## Installation
+
+Shipped in the `biology` environment: `biopython` (`Bio`), `r-ape`, `r-phangorn`. Extras through `install_science_packages`:
+
+| Need | Language | Spec | Platform note |
+|------|----------|------|---------------|
+| Multiple sequence alignment binary | python | `mafft` or `muscle` (bioconda) | macOS only; on Windows use `Bio.Align.PairwiseAligner` progressively or ask for a pre-aligned file |
+| Fast local alignment / database search | python | `blast` (bioconda) | macOS only; needs a local database the user provides |
+| Primer design | python | `primer3-py` | conda-forge, all platforms |
+| Reading BAM/SAM/VCF | python | `pysam` (bioconda, macOS) / `cyvcf2` | Windows: parse text VCF with pandas |
+| Protein structure files | python | `biopython` already reads PDB/mmCIF (`Bio.PDB`) | |
+| Tree plotting in R with annotations | r | `bioconductor-ggtree` (macOS) | Fallback: `ape::plot.phylo` |
+
+Compatibility traps: `Bio.pairwise2` is deprecated — use `Bio.Align.PairwiseAligner`. `Bio.SeqUtils.GC` was renamed to `gc_fraction` (returns 0–1). `Seq.translate()` on a length not divisible by 3 warns; slice to `len // 3 * 3` explicitly. `SeqIO.parse` returns a generator — wrap in `list()` before re-using.
+
+## Workflow
+
+1. **Identify what was given.** Format (FASTA, FASTQ, GenBank, EMBL, raw text), alphabet (DNA/RNA/protein — infer from composition and confirm), count, lengths, and any ambiguity codes (`N`, `R`, `Y`). Print a summary table (`id, length, GC, N-fraction`). For GenBank, list features (`CDS`, `gene`, `exon`) with coordinates and strand.
+2. **Answer the concrete question with the smallest correct tool** — see the recipe list below. Print intermediate values (positions are **1-based** in reports, 0-based in code; say which every time).
+3. **Alignment.** Two sequences: `PairwiseAligner` with a named scoring scheme (`mode="global"`, `substitution_matrix=substitution_matrices.load("BLOSUM62")` for protein; `match_score=2, mismatch_score=-1, open_gap_score=-2, extend_gap_score=-0.5` for nucleotides). Report score, identity (%) computed over aligned columns excluding gaps **and** over the shorter sequence length, and print the alignment in blocks. Many sequences: MAFFT/MUSCLE via `subprocess.run([...], capture_output=True, text=True, check=True)` from the kernel, output to the scratch directory, then parse with `AlignIO`. Always state the aligner and parameters.
+4. **Variants and conservation.** From an alignment, compute per-column conservation (Shannon entropy or fraction identical to reference) and list differences against a named reference as `ref_pos ref_base alt_base` (protein: `p.Ala123Thr` style); for a CDS, translate both and classify synonymous / missense / nonsense / frameshift. Plot conservation along the sequence as a matplotlib line/bar figure.
+5. **Phylogeny.** In R: read the alignment (`ape::read.dna` / `phangorn::read.phyDat`), choose a model (`modelTest` for ML; `dist.dna(model="K80")` or `"TN93"` for distance), build NJ (`nj`) for a quick tree and ML (`pml` → `optim.pml`) for the reported one, bootstrap (`bootstrap.pml` or `boot.phylo`, ≥ 100 replicates, `set.seed(1)`), root on a stated outgroup or midpoint (`phangorn::midpoint`), and plot with `plot.phylo` + `nodelabels` for bootstrap ≥ 70. Save the tree as Newick (`write.tree`) to `SCIENCE_ARTIFACT_DIR/tree.nwk` and the figure via `png()`/`dev.off()` or `ggsave` (declared in `raster_artifacts`). `scripts/phylo_pipeline.R` runs distance + ML + bootstrap in one call.
+6. **Deliver.** Tables as CSV (`orfs.csv`, `primers.csv`, `variants.csv`), sequences as FASTA (`SeqIO.write(records, path, "fasta")` — FASTA is not auto-captured; write it under `SCIENCE_ARTIFACT_DIR` and also print it in the reply when short), figures as PNG. Use `annotate_artifact` on the main figure or table.
+
+## Recipes (Biopython)
+
+```python
+from Bio import SeqIO, Align
+from Bio.Seq import Seq
+from Bio.SeqUtils import gc_fraction, MeltingTemp as mt, molecular_weight
+from Bio.SeqUtils.ProtParam import ProteinAnalysis
+from Bio.Align import substitution_matrices
+from Bio.Restriction import RestrictionBatch, Analysis
+
+recs = list(SeqIO.parse(path, "fasta"))                     # or "genbank", "fastq"
+s = recs[0].seq
+gc = gc_fraction(s) * 100                                    # percent
+rc = s.reverse_complement()
+prot = s[: len(s) // 3 * 3].translate(table=1, to_stop=False)  # table=11 for bacteria, 2 for vertebrate mito
+```
+
+- **Sliding-window GC**: `[gc_fraction(s[i:i+w]) for i in range(0, len(s)-w+1, step)]`; plot vs midpoint.
+- **ORFs** (all six frames, ATG→stop, min length): `scripts/seq_tools.py::find_orfs(seq, min_aa=100, table=1)` returns a DataFrame `frame, strand, start, end, length_nt, protein`.
+- **Restriction sites**: `Analysis(RestrictionBatch(["EcoRI","BamHI","HindIII"]), s, linear=True).full()` → dict enzyme → cut positions; `RestrictionBatch(first=[], suppliers=["N"])` for a commercial set.
+- **Primer check**: length 18–25, GC 40–60 %, Tm 55–65 °C (`mt.Tm_NN(primer, Na=50, dnac1=250, dnac2=0)`), ΔTm between pair ≤ 3 °C, no runs ≥ 4 identical bases, 3′ GC clamp (1–2 G/C in last 5), self-complementarity via `PairwiseAligner` local score of primer vs its reverse complement; `scripts/seq_tools.py::primer_report`. Design new primers with `primer3-py` if installed; otherwise scan candidates with the same rules.
+- **Motif search** (IUPAC allowed): `Bio.SeqUtils.nt_search(str(s), "GGATCC")` → `[pattern, pos1, pos2, ...]` (0-based); regex with `Bio.Seq` translated IUPAC codes for degenerate motifs.
+- **Codon usage**: count codons in-frame from CDS features → RSCU table; `scripts/seq_tools.py::codon_usage`.
+- **Protein properties**: `ProteinAnalysis(str(prot)).molecular_weight()`, `.isoelectric_point()`, `.gravy()`, `.instability_index()`, `.secondary_structure_fraction()`; strip `*` first.
+- **FASTQ quality**: `rec.letter_annotations["phred_quality"]` → per-position mean Phred plot; report % reads with mean Q ≥ 30.
+- **GenBank feature extraction**: `[f for f in rec.features if f.type == "CDS"]`, `f.location.extract(rec.seq)`, `f.qualifiers.get("gene", ["?"])[0]`.
+
+## Integrity rules
+
+1. **State the genetic code table and the coordinate convention** in every result.
+2. **An alignment identity without the aligner and parameters is meaningless**; report both, plus alignment length and gap count.
+3. **Never present a pure-Python pairwise alignment as a BLAST result** or invent E-values; if a database search is needed, say it requires BLAST against a named database.
+4. **Bootstrap values are support for clades, not probabilities of the tree**; do not report a phylogeny without them or without the substitution model.
+5. **Do not silently trim, reverse-complement, or "fix" a user's sequence** — do it explicitly and print what changed.
+6. **Ambiguity codes and lowercase (soft-masked) bases** are reported, not dropped.
+
+Files: `scripts/seq_tools.py` (`find_orfs`, `primer_report`, `codon_usage`, `pairwise_identity`), `scripts/phylo_pipeline.R` (`build_trees(alignment_path, outgroup, out_dir)`), `references/phylogenetics.md` (model choice, rooting, reading a tree honestly).

--- a/apps/desktop/resources/skills/sequence-analysis/references/phylogenetics.md
+++ b/apps/desktop/resources/skills/sequence-analysis/references/phylogenetics.md
@@ -1,0 +1,50 @@
+# Phylogenetics — model choice, rooting, and honest reading of a tree
+
+## Before building anything
+
+- **Alignment quality decides the tree.** Inspect it: print columns with > 50 % gaps, check that protein-coding DNA is aligned in frame (align translated sequences, back-translate if needed), and consider trimming poorly aligned ends. Report alignment length and the fraction of gap columns.
+- **Orthologs, not paralogs.** A gene tree with mixed paralogs is not a species tree. Say what the tree represents.
+- **Enough signal?** Fewer than ~300 informative sites rarely resolve deep nodes; low bootstrap values are the expected honest result.
+
+## Substitution models
+
+| Data | Quick distance | ML candidates | Notes |
+|------|----------------|---------------|-------|
+| DNA, closely related | K80 / TN93 distance, NJ | HKY+G, GTR+G(+I) | `modelTest` picks by BIC; `+I` with `+G` is often over-parameterized — prefer `+G` alone when BIC is close |
+| DNA, coding | as above, or codon-position partitions | GTR+G | State whether 3rd positions were included |
+| Protein | JTT / LG distance | LG+G, WAG+G, JTT+G | LG is the usual best; `+F` (empirical frequencies) when alignment is long |
+| 16S rRNA / ITS | TN93 | GTR+G | Trim to a common region first |
+
+Report: model, why (BIC), and the tool/version (`packageVersion("phangorn")`).
+
+## Methods and what they claim
+
+- **NJ**: fast, distance-based, no explicit optimality; fine for a first look and for > 500 taxa. Never the only tree in a paper figure.
+- **Maximum likelihood** (`optim.pml`, or IQ-TREE/RAxML if installed via bioconda): the standard reported tree; bootstrap ≥ 100 (≥ 1000 with UFBoot in IQ-TREE).
+- **Bayesian** (MrBayes/BEAST): posterior probabilities, divergence times — outside this environment; say so if asked.
+
+## Rooting
+
+An unrooted ML tree has no direction of time. Root with a **named outgroup** the user justifies (a taxon known to be outside the ingroup), or **midpoint** only when rates are approximately clock-like and no outgroup exists — and label the figure accordingly. Rooting choice changes which groups are monophyletic; report it explicitly.
+
+## Reading the tree
+
+- Bootstrap ≥ 70 % (ML) is conventional "support"; < 50 % nodes should be shown as unresolved (collapse with `ape::di2multi` after setting low-support branch lengths to 0, or just say the node is unsupported).
+- Branch lengths are substitutions per site, not time. Similar-looking clades at different depths are not "equally old".
+- Ladder-like topologies with short internal branches indicate rapid radiation or insufficient signal — not a confident order of divergence.
+- A single sequence on a long branch may be a misaligned or contaminated sequence (long-branch attraction); check its alignment before interpreting.
+
+## Tree figure checklist
+
+Tip labels legible (≤ ~60 tips per figure; otherwise collapse clades), bootstrap values on nodes ≥ 70, scale bar, outgroup at the bottom or top, model and replicate count in the title or caption, and the Newick file delivered alongside (`tree_ml.nwk`) so the tree is reusable.
+
+## Useful ape / phangorn calls
+
+```r
+tr <- read.tree("tree_ml.nwk")
+tr <- ladderize(tr)                                     # tidy plotting order
+is.monophyletic(tr, tips = c("A", "B", "C"))
+cophenetic(tr)["A", "B"]                                # patristic distance
+drop.tip(tr, "Contaminant_sample")
+dist.topo(tr_ml, tr_nj)                                 # Robinson–Foulds distance between methods
+```

--- a/apps/desktop/resources/skills/sequence-analysis/scripts/phylo_pipeline.R
+++ b/apps/desktop/resources/skills/sequence-analysis/scripts/phylo_pipeline.R
@@ -1,0 +1,60 @@
+# Distance (NJ) + maximum-likelihood tree with bootstrap from an aligned FASTA.
+#
+#   source(file.path(SKILL_DIR, "scripts/phylo_pipeline.R"))
+#   res <- build_trees("aligned.fasta", outgroup = "Outgroup_taxon", out_dir = Sys.getenv("SCIENCE_ARTIFACT_DIR"))
+#   res$ml_tree ; res$model ; res$figures   # declare res$figures in raster_artifacts
+#
+# Requires ape + phangorn (shipped in the biology environment). Alignment must
+# already be aligned (equal lengths); align first with MAFFT/MUSCLE or provide one.
+
+suppressPackageStartupMessages({ library(ape); library(phangorn) })
+
+build_trees <- function(alignment_path, outgroup = NULL, out_dir = ".", type = c("DNA", "AA"),
+                        bootstrap = 100, seed = 1, prefix = "tree") {
+  type <- match.arg(type)
+  set.seed(seed)
+  dir.create(out_dir, showWarnings = FALSE, recursive = TRUE)
+  phy <- read.phyDat(alignment_path, format = "fasta", type = type)
+  taxa <- names(phy)
+  if (!is.null(outgroup) && !outgroup %in% taxa) stop("outgroup '", outgroup, "' not among taxa: ", paste(taxa, collapse = ", "))
+
+  # --- distance tree ----------------------------------------------------------
+  dm <- if (type == "DNA") dist.ml(phy, model = "JC69") else dist.ml(phy, model = "JTT")
+  nj_tree <- NJ(dm)
+
+  # --- model selection + ML ---------------------------------------------------
+  mt <- modelTest(phy, tree = nj_tree, model = if (type == "DNA") c("JC", "K80", "HKY", "GTR") else c("JTT", "LG", "WAG"),
+                  G = TRUE, I = TRUE, control = pml.control(trace = 0))
+  best <- mt$Model[which.min(mt$BIC)]
+  fit <- as.pml(mt, best)                       # phangorn >= 2.8: builds pml from the modelTest env
+  fit <- optim.pml(fit, optNni = TRUE, optGamma = grepl("G", best), optInv = grepl("I", best),
+                   rearrangement = "stochastic", control = pml.control(trace = 0))
+  bs <- bootstrap.pml(fit, bs = bootstrap, optNni = TRUE, control = pml.control(trace = 0))
+  ml_tree <- plotBS(fit$tree, bs, type = "none")   # attaches node labels (bootstrap %) without plotting
+
+  # --- rooting ----------------------------------------------------------------
+  root_tree <- function(tr) {
+    if (!is.null(outgroup)) root(tr, outgroup = outgroup, resolve.root = TRUE) else midpoint(tr)
+  }
+  nj_tree <- root_tree(nj_tree)
+  ml_tree <- root_tree(ml_tree)
+
+  # --- outputs ----------------------------------------------------------------
+  nwk <- file.path(out_dir, paste0(prefix, "_ml.nwk"))
+  write.tree(ml_tree, nwk)
+  write.tree(nj_tree, file.path(out_dir, paste0(prefix, "_nj.nwk")))
+  write.csv(mt[, c("Model", "df", "logLik", "AIC", "BIC")], file.path(out_dir, paste0(prefix, "_model_test.csv")), row.names = FALSE)
+
+  fig <- file.path(out_dir, paste0(prefix, "_ml.png"))
+  png(fig, width = 1800, height = 1400, res = 200)
+  par(mar = c(3, 1, 3, 1))
+  plot.phylo(ml_tree, cex = 0.8, label.offset = 0.002, main = sprintf("ML tree (%s), %d bootstrap replicates", best, bootstrap))
+  bs_vals <- suppressWarnings(as.numeric(ml_tree$node.label))
+  show <- !is.na(bs_vals) & bs_vals >= 70
+  if (any(show)) nodelabels(text = bs_vals[show], node = (Ntip(ml_tree) + 1:Nnode(ml_tree))[show], frame = "none", cex = 0.65, adj = c(1.2, -0.3))
+  add.scale.bar()
+  dev.off()
+
+  list(nj_tree = nj_tree, ml_tree = ml_tree, model = best, model_test = mt, bootstrap = bs,
+       figures = fig, newick = nwk)
+}

--- a/apps/desktop/resources/skills/sequence-analysis/scripts/seq_tools.py
+++ b/apps/desktop/resources/skills/sequence-analysis/scripts/seq_tools.py
@@ -1,0 +1,146 @@
+"""Small, dependency-light sequence helpers on top of Biopython.
+
+    exec(open(f"{SKILL_DIR}/scripts/seq_tools.py").read())
+    orfs = find_orfs(seq, min_aa=100, table=1)
+    rep  = primer_report({"F": "ACGT...", "R": "TTGA..."}, template=seq)
+    rscu = codon_usage(cds_seq)
+    ident = pairwise_identity(seq_a, seq_b, kind="dna")
+"""
+from __future__ import annotations
+
+import re
+from collections import Counter
+
+import pandas as pd
+from Bio.Seq import Seq
+from Bio.Align import PairwiseAligner, substitution_matrices
+from Bio.Data import CodonTable
+from Bio.SeqUtils import gc_fraction, MeltingTemp as mt
+
+
+def find_orfs(seq, min_aa: int = 100, table: int = 1, start_codons=("ATG",)) -> pd.DataFrame:
+    """All ORFs (start codon → in-frame stop) on both strands in the six frames.
+    Coordinates are 1-based, inclusive, on the forward strand. `length_nt` includes the stop."""
+    seq = Seq(str(seq).upper())
+    n = len(seq)
+    stops = set(CodonTable.unambiguous_dna_by_id[table].stop_codons)
+    rows = []
+    for strand, s in ((+1, seq), (-1, seq.reverse_complement())):
+        for frame in range(3):
+            i = frame
+            while i + 3 <= n:
+                codon = str(s[i:i + 3])
+                if codon in start_codons:
+                    j = i
+                    while j + 3 <= n and str(s[j:j + 3]) not in stops:
+                        j += 3
+                    if j + 3 <= n:                      # found a stop
+                        length = j + 3 - i
+                        if length // 3 - 1 >= min_aa:
+                            if strand == 1:
+                                start, end = i + 1, j + 3
+                            else:
+                                start, end = n - (j + 3) + 1, n - i
+                            prot = str(s[i:j + 3].translate(table=table))
+                            rows.append(dict(frame=frame + 1, strand="+" if strand == 1 else "-", start=start, end=end,
+                                             length_nt=length, length_aa=length // 3 - 1, protein=prot.rstrip("*")))
+                        i = j + 3                       # continue after this ORF
+                        continue
+                i += 3
+    return pd.DataFrame(rows).sort_values(["length_nt"], ascending=False).reset_index(drop=True) if rows else \
+        pd.DataFrame(columns=["frame", "strand", "start", "end", "length_nt", "length_aa", "protein"])
+
+
+def _self_dimer_score(p: str) -> float:
+    aligner = PairwiseAligner(mode="local", match_score=1, mismatch_score=-1, open_gap_score=-2, extend_gap_score=-1)
+    return aligner.score(p, str(Seq(p).reverse_complement()))
+
+
+def _hairpin(p: str, stem: int = 4) -> bool:
+    rc = str(Seq(p).reverse_complement())
+    return any(p[i:i + stem] in rc[:len(rc) - i - stem] for i in range(len(p) - 2 * stem - 3))
+
+
+def primer_report(primers: dict[str, str], template=None) -> pd.DataFrame:
+    """Rule-based primer QC. Columns: name, seq, length, gc_pct, tm_c, runs, gc_clamp, self_dimer,
+    hairpin, template_hits_fwd, template_hits_rev, flags (semicolon list of failed rules)."""
+    rows = []
+    tms = {}
+    for name, p in primers.items():
+        p = p.upper().replace(" ", "")
+        gc = gc_fraction(p) * 100
+        tm = mt.Tm_NN(p, Na=50, dnac1=250, dnac2=0)
+        tms[name] = tm
+        runs = max((len(m.group(0)) for m in re.finditer(r"(A+|C+|G+|T+)", p)), default=0)
+        clamp = sum(1 for b in p[-5:] if b in "GC")
+        sd = _self_dimer_score(p)
+        hp = _hairpin(p)
+        flags = []
+        if not 18 <= len(p) <= 25: flags.append("length")
+        if not 40 <= gc <= 60: flags.append("GC%")
+        if not 55 <= tm <= 65: flags.append("Tm")
+        if runs >= 4: flags.append("run>=4")
+        if clamp == 0 or clamp > 3: flags.append("3'clamp")
+        if sd >= 8: flags.append("self-dimer")
+        if hp: flags.append("hairpin")
+        hits_f = hits_r = None
+        if template is not None:
+            t = str(template).upper()
+            hits_f = t.count(p)
+            hits_r = t.count(str(Seq(p).reverse_complement()))
+            if hits_f + hits_r != 1: flags.append("template-hits!=1")
+        rows.append(dict(name=name, seq=p, length=len(p), gc_pct=round(gc, 1), tm_c=round(tm, 1), runs=runs,
+                         gc_clamp=clamp, self_dimer=sd, hairpin=hp, template_hits_fwd=hits_f, template_hits_rev=hits_r,
+                         flags=";".join(flags)))
+    df = pd.DataFrame(rows)
+    if len(tms) == 2:
+        a, b = tms.values()
+        if abs(a - b) > 3:
+            df["flags"] = df["flags"].apply(lambda f: ";".join([x for x in [f, "pair-dTm>3"] if x]))
+    return df
+
+
+def codon_usage(cds, table: int = 1) -> pd.DataFrame:
+    """Codon counts, frequency per thousand, and RSCU for an in-frame CDS."""
+    s = str(cds).upper()
+    s = s[: len(s) // 3 * 3]
+    codons = [s[i:i + 3] for i in range(0, len(s), 3)]
+    counts = Counter(c for c in codons if set(c) <= set("ACGT"))
+    fwd = CodonTable.unambiguous_dna_by_id[table].forward_table
+    aa_of = dict(fwd)
+    for stop in CodonTable.unambiguous_dna_by_id[table].stop_codons:
+        aa_of[stop] = "*"
+    rows = []
+    total = sum(counts.values())
+    by_aa = {}
+    for c, aa in aa_of.items():
+        by_aa.setdefault(aa, []).append(c)
+    for aa, syn in sorted(by_aa.items()):
+        tot_aa = sum(counts[c] for c in syn)
+        for c in sorted(syn):
+            n = counts[c]
+            rscu = (n * len(syn) / tot_aa) if tot_aa else float("nan")
+            rows.append(dict(amino_acid=aa, codon=c, count=n, per_thousand=round(1000 * n / total, 2) if total else 0,
+                             rscu=round(rscu, 3)))
+    return pd.DataFrame(rows)
+
+
+def pairwise_identity(a, b, kind: str = "dna") -> dict:
+    """Global alignment with stated parameters; returns score, identity over aligned columns
+    (gaps excluded), identity over the shorter sequence, alignment length, gaps, and the alignment text."""
+    aligner = PairwiseAligner(mode="global")
+    if kind == "protein":
+        aligner.substitution_matrix = substitution_matrices.load("BLOSUM62")
+        aligner.open_gap_score, aligner.extend_gap_score = -10, -0.5
+        params = "BLOSUM62, gap open -10, extend -0.5"
+    else:
+        aligner.match_score, aligner.mismatch_score = 2, -1
+        aligner.open_gap_score, aligner.extend_gap_score = -2, -0.5
+        params = "match 2, mismatch -1, gap open -2, extend -0.5"
+    aln = aligner.align(str(a), str(b))[0]
+    cols = aln.counts()             # identities, mismatches, gaps (Biopython >= 1.80)
+    aligned_cols = cols.identities + cols.mismatches
+    return dict(score=aln.score, parameters=params, alignment_length=aln.length, gaps=cols.gaps,
+                identity_aligned_pct=round(100 * cols.identities / aligned_cols, 2) if aligned_cols else 0.0,
+                identity_shorter_pct=round(100 * cols.identities / min(len(a), len(b)), 2),
+                alignment=str(aln))

--- a/apps/desktop/resources/skills/sequence-analysis/scripts/seq_tools.py
+++ b/apps/desktop/resources/skills/sequence-analysis/scripts/seq_tools.py
@@ -137,10 +137,15 @@ def pairwise_identity(a, b, kind: str = "dna") -> dict:
         aligner.match_score, aligner.mismatch_score = 2, -1
         aligner.open_gap_score, aligner.extend_gap_score = -2, -0.5
         params = "match 2, mismatch -1, gap open -2, extend -0.5"
-    aln = aligner.align(str(a), str(b))[0]
+    sa, sb = str(a), str(b)
+    if not sa or not sb:
+        return dict(score=0.0, parameters=params, alignment_length=0, gaps=0,
+                    identity_aligned_pct=0.0, identity_shorter_pct=0.0, alignment="")
+    aln = aligner.align(sa, sb)[0]
     cols = aln.counts()             # identities, mismatches, gaps (Biopython >= 1.80)
     aligned_cols = cols.identities + cols.mismatches
+    min_len = min(len(sa), len(sb))
     return dict(score=aln.score, parameters=params, alignment_length=aln.length, gaps=cols.gaps,
                 identity_aligned_pct=round(100 * cols.identities / aligned_cols, 2) if aligned_cols else 0.0,
-                identity_shorter_pct=round(100 * cols.identities / min(len(a), len(b)), 2),
+                identity_shorter_pct=round(100 * cols.identities / min_len, 2) if min_len else 0.0,
                 alignment=str(aln))

--- a/apps/desktop/resources/skills/single-cell-analysis/SKILL.md
+++ b/apps/desktop/resources/skills/single-cell-analysis/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: single-cell-analysis
+description: "Single-cell RNA-seq analysis with scanpy/anndata (Python, shipped) or Seurat (R, installable) — 10x/h5ad/CSV loading, cell and gene QC (mito %, counts, doublets), normalization, HVG selection, PCA, neighbors, Leiden clustering, UMAP, marker genes, cell-type annotation, per-cluster composition, and pseudobulk DE between conditions. Use whenever a user mentions cells as rows, clusters, UMAP/t-SNE, marker genes, cell types, 10x Genomics output, or an .h5ad/.rds object. Trigger terms: 单细胞、scRNA-seq、10x、UMAP、聚类、Leiden、marker 基因、细胞类型注释、Seurat、scanpy、anndata、拟时序."
+license: MIT license
+metadata:
+  version: "1.0"
+  skill-author: PaperMachine community
+---
+
+# Single-Cell RNA-seq Analysis
+
+Run the standard scanpy pipeline in the session's persistent Python kernel, keeping the `AnnData` object in memory across turns and writing only deliverables (figures, marker tables, cluster annotations) to `SCIENCE_ARTIFACT_DIR`. The result a reviewer trusts states QC thresholds with the cell counts they removed, uses an HVG set and PCA count that were chosen and recorded, resolves clustering at a stated resolution, and annotates cell types from marker evidence shown in a figure — never from cluster number alone.
+
+## Installation
+
+Shipped in the `biology` environment: `scanpy`, `anndata`, `leidenalg`, `python-igraph`, `umap-learn`, `scikit-learn`. Install extras with `install_science_packages`:
+
+| Need | Language | Spec |
+|------|----------|------|
+| 10x `.h5` files | python | `h5py` (usually already present), `pytables` for `.h5ad` compression |
+| Doublet detection | python | `scrublet` (or `scanpy.pp.scrublet`, available since scanpy 1.10 — prefer that, no install) |
+| Batch integration | python | `harmonypy` (Harmony) or `scanorama`; `scvi-tools` is heavy (PyTorch) — ask before installing |
+| Cell-type reference annotation | python | `celltypist` |
+| Seurat in R | r | `r-seurat` (conda-forge; ~1 GB with dependencies — ask first) |
+| Loom / MTX helpers | python | `loompy` |
+
+Compatibility traps: scanpy ≥ 1.10 `sc.pp.highly_variable_genes(flavor="seurat_v3")` needs **raw counts** in `adata.X` or `layer=`; call it before `normalize_total`. `sc.tl.leiden` defaults changed — pass `flavor="igraph", n_iterations=2, directed=False` explicitly. Keep `adata.layers["counts"]`. Never `import scvi` without asking.
+
+## Workflow
+
+Persist `adata` as a kernel variable; if the kernel restarted, reload and replay recorded steps.
+
+1. **Load.** `sc.read_10x_mtx(dir, var_names="gene_symbols", cache=False)`, `sc.read_10x_h5`, `sc.read_h5ad`, or `sc.read_csv(...).T` when genes are rows. Set `adata.var_names_make_unique()`. Store raw counts: `adata.layers["counts"] = adata.X.copy()`. Print `adata` dimensions and confirm integer counts.
+2. **QC metrics.** Flag mito (`MT-`/`mt-`), ribosomal (`RPS|RPL`), haemoglobin (`^HB[^(P)]`) genes; `sc.pp.calculate_qc_metrics(adata, qc_vars=["mt","ribo","hb"], percent_top=[20], log1p=True, inplace=True)`. Plot violins and scatter of counts vs genes coloured by mito %. Save `qc_violin.png` (declare in `raster_artifacts`).
+3. **Filter.** Default: genes in ≥ 3 cells; cells with 200 ≤ n_genes, mito % < 20 (human tissue; 5–10 % for PBMC). Prefer data-driven MAD cutoffs (`scripts/qc_thresholds.py`). Report cells before → after per sample. Run doublet detection (`sc.pp.scrublet(adata, batch_key="sample")`) and report doublet fraction (< 10 %).
+4. **Normalize & features.** `sc.pp.normalize_total(adata, target_sum=1e4)`; `sc.pp.log1p(adata)`; HVGs: `sc.pp.highly_variable_genes(adata, n_top_genes=2000, flavor="seurat_v3", layer="counts", batch_key="sample")`. Keep full matrix; subset to HVGs in PCA via `use_highly_variable=True`.
+5. **Reduce, integrate, cluster.** `sc.tl.pca(adata, n_comps=50, mask_var="highly_variable")`; inspect elbow for `n_pcs` (typically 20–40). If batch effect exists, integrate with Harmony (`sc.external.pp.harmony_integrate(adata, key="sample")`, `use_rep="X_pca_harmony"`). `sc.pp.neighbors(adata, n_neighbors=15, n_pcs=n_pcs)`; `sc.tl.umap(adata, random_state=0)`; `sc.tl.leiden(adata, resolution=1.0, flavor="igraph", n_iterations=2, directed=False, key_added="leiden_1.0")`. Test 2–3 resolutions (0.3/0.6/1.0); choose one and record rationale.
+6. **Markers.** `sc.tl.rank_genes_groups(adata, "leiden_1.0", method="wilcoxon", pts=True)`; filter `pct_nz_group > 0.25`, `logfoldchanges > 1`, `pvals_adj < 0.05` → write `markers_by_cluster.csv`. Plot dot plot of top 5 markers per cluster and canonical marker UMAPs (`references/marker_genes.md`).
+7. **Annotate.** Map cluster → cell type in a dict, store as `adata.obs["cell_type"]`, and justify labels in a table. For mixed clusters, label `Ambiguous (cluster N)` and propose subclustering. CellTypist is a second opinion, not the final word.
+8. **Composition & condition DE.** Cross-tab `cell_type × sample` → stacked bar. For condition differences within cell types, use **pseudobulk**: sum counts per (sample, cell_type) and run pyDESeq2 with replicates. Cell-level Wilcoxon between conditions inflates significance; use for exploratory ranking only.
+9. **Deliver.** Headline UMAP coloured by `cell_type` (`legend_loc="on data"`) with `annotate_artifact`; `cell_annotations.csv`; `markers_by_cluster.csv`; save `f"{SCIENCE_STATE_DIR}/processed.h5ad"` for state persistence.
+
+## Figures
+
+Use `sc.pl.*` with `show=False, return_fig=True` (or `ax=`) and save through `fig.savefig(path, dpi=150, bbox_inches="tight")` so the figure stays editable in the viewer; `sc.settings.figdir`/`save=` writes outside `SCIENCE_ARTIFACT_DIR` and is not captured. Point sizes: `size=` scaled to cell count (≈ 120000 / n_cells). Colour categorical fields with `sc.pl.umap(..., palette="tab20")` and never more than ~20 categories in one legend.
+
+## Integrity rules
+
+1. **Report QC thresholds and the number of cells each removed**, per sample.
+2. **Clustering resolution is a choice, not a discovery.** State it; do not describe cluster count as a biological finding.
+3. **Marker-based annotation shows its evidence** (dot plot or feature UMAP) for every label.
+4. **Differential expression across conditions uses pseudobulk** with biological replicates; single-cell Wilcoxon p-values are exploratory.
+5. **Integration removes biology as well as batch.** Show the uncorrected UMAP too, and report whether condition and batch are confounded.
+6. **Seeds:** `random_state=0` in PCA/UMAP/Leiden/Scrublet; print `sc.logging.print_header()` in the report.
+7. **Trajectory (PAGA/diffusion pseudotime)** is only meaningful within a continuous lineage — do not run it across unrelated cell types; `references/trajectory.md`.
+
+## Quick reference
+
+- Fast look: `adata.obs.groupby("sample")[["total_counts","n_genes_by_counts","pct_counts_mt"]].median()`.
+- Subset to a lineage and recluster: `sub = adata[adata.obs.cell_type == "T cell"].copy()`; redo HVG → PCA → neighbors → Leiden on `sub` (never reuse the parent embedding).
+- Seurat interop: `SeuratDisk`/`sceasy` conversions are fragile — prefer exporting `counts` MTX + `obs` CSV and rebuilding.
+- Files: `scripts/qc_thresholds.py` (`mad_outliers`, `qc_summary`, and `pseudobulk` — aggregate raw counts to sample × cell type for pyDESeq2), `references/marker_genes.md` (canonical markers by tissue), `references/trajectory.md`.

--- a/apps/desktop/resources/skills/single-cell-analysis/references/marker_genes.md
+++ b/apps/desktop/resources/skills/single-cell-analysis/references/marker_genes.md
@@ -1,0 +1,64 @@
+# Canonical marker genes (human symbols; mouse: capitalize first letter only, e.g. `Ptprc`)
+
+Use these as a starting checklist for a feature-UMAP panel and a dot plot. A label needs at least two concordant markers **and** the absence of the neighbouring lineage's markers. Always verify against the user's tissue and species; expression is context-dependent.
+
+## Immune (PBMC / tumour infiltrate / spleen)
+
+| Cell type | Positive markers | Notes |
+|-----------|------------------|-------|
+| All immune | `PTPRC` (CD45) | Absent in epithelial/stromal |
+| T cells | `CD3D`, `CD3E`, `CD2` | |
+| CD4 T | `CD4`, `IL7R`, `CCR7` (naive), `FOXP3`+`IL2RA` (Treg) | `CD4` mRNA is low; rely on `IL7R` + absence of `CD8A` |
+| CD8 T | `CD8A`, `CD8B`, `GZMK` (memory), `GZMB`+`PRF1` (cytotoxic) | |
+| NK | `NKG7`, `GNLY`, `KLRD1`, `NCAM1`, no `CD3E` | `NKG7`/`GNLY` also in cytotoxic CD8 |
+| B cells | `MS4A1` (CD20), `CD79A`, `CD79B`, `CD19` | |
+| Plasma cells | `MZB1`, `JCHAIN`, `SDC1`, `XBP1`, high `IGHG*` | Low `MS4A1` |
+| Classical monocytes | `CD14`, `LYZ`, `S100A8`, `S100A9` | |
+| Non-classical monocytes | `FCGR3A` (CD16), `MS4A7`, `LST1` | |
+| Macrophages | `CD68`, `C1QA`, `C1QB`, `APOE`, `MRC1` (M2-like) | Tissue-resident |
+| cDC1 | `CLEC9A`, `XCR1` | Rare |
+| cDC2 | `CD1C`, `FCER1A`, `CLEC10A` | |
+| pDC | `LILRA4`, `IL3RA`, `CLEC4C`, `IRF7` | |
+| Mast cells | `TPSAB1`, `CPA3`, `KIT` | |
+| Neutrophils | `FCGR3B`, `CSF3R`, `S100A8`, `CXCR2` | Poorly captured by 10x; low RNA |
+| Platelets / megakaryocytes | `PPBP`, `PF4` | Often a contaminant cluster |
+| Erythrocytes | `HBB`, `HBA1`, `HBA2` | Remove unless studied |
+| Proliferating (any lineage) | `MKI67`, `TOP2A`, `STMN1` | Sub-annotate by lineage markers |
+
+## Epithelial / stromal / vascular
+
+| Cell type | Markers |
+|-----------|---------|
+| Epithelial (general) | `EPCAM`, `KRT8`, `KRT18`, `KRT19` |
+| Basal epithelial | `KRT5`, `KRT14`, `TP63` |
+| Secretory / goblet | `MUC5AC`, `MUC2`, `TFF3` |
+| Enterocytes | `FABP1`, `APOA1`, `VIL1` |
+| Hepatocytes | `ALB`, `APOA2`, `TTR`, `CYP3A4` |
+| Alveolar type 1 | `AGER`, `PDPN`, `CAV1` |
+| Alveolar type 2 | `SFTPC`, `SFTPB`, `LAMP3` |
+| Fibroblasts | `COL1A1`, `COL1A2`, `DCN`, `LUM`, `PDGFRA` |
+| Myofibroblasts / CAF | `ACTA2`, `TAGLN`, `POSTN`, `FAP` |
+| Pericytes | `RGS5`, `PDGFRB`, `MCAM`, `KCNJ8` |
+| Smooth muscle | `MYH11`, `CNN1`, `DES` |
+| Endothelial | `PECAM1`, `VWF`, `CDH5`, `CLDN5` |
+| Lymphatic endothelial | `PROX1`, `LYVE1`, `PDPN` |
+| Mesothelial | `MSLN`, `UPK3B`, `WT1` |
+
+## Brain
+
+| Cell type | Markers |
+|-----------|---------|
+| Excitatory neurons | `SLC17A7`, `SATB2`, `NRGN` |
+| Inhibitory neurons | `GAD1`, `GAD2`, `SLC32A1` |
+| Astrocytes | `GFAP`, `AQP4`, `SLC1A2`, `ALDH1L1` |
+| Oligodendrocytes | `MBP`, `MOBP`, `PLP1`, `MOG` |
+| OPC | `PDGFRA`, `VCAN`, `OLIG1` |
+| Microglia | `CX3CR1`, `P2RY12`, `TMEM119`, `CSF1R` |
+| Endothelial | `CLDN5`, `FLT1` |
+
+## Quality flags worth plotting alongside
+
+- `pct_counts_mt` high + low `n_genes` → dying cells, not a cell type.
+- `PPBP`/`HBB` co-expression with immune markers → ambient RNA or doublets.
+- Two lineage marker sets in one cluster (e.g. `CD3E` + `LYZ`) → doublet cluster; check the Scrublet score distribution for that cluster.
+- A cluster defined only by ribosomal (`RPS*`/`RPL*`) or stress genes (`FOS`, `JUN`, `HSPA1A`) → dissociation/handling artefact; report, do not name as a cell type.

--- a/apps/desktop/resources/skills/single-cell-analysis/references/trajectory.md
+++ b/apps/desktop/resources/skills/single-cell-analysis/references/trajectory.md
@@ -1,0 +1,39 @@
+# Trajectory and pseudotime — when and how
+
+## Preconditions (all must hold)
+
+1. The cells form **one continuous process** (differentiation, activation, cell cycle) — not a set of terminally distinct types. Run trajectory on a lineage subset (`sub = adata[adata.obs.cell_type.isin([...])].copy()`), recomputed from HVG → PCA → neighbors on that subset.
+2. A **root** is biologically justified (stem/progenitor markers, earliest time point) and named before running.
+3. Batch effects within the subset have been checked; pseudotime happily orders cells by sample if you let it.
+
+If any fails, report a UMAP with marker gradients instead and say why pseudotime was not computed.
+
+## PAGA + diffusion pseudotime (scanpy, no install)
+
+```python
+sc.pp.neighbors(sub, n_neighbors=30, n_pcs=30)
+sc.tl.leiden(sub, resolution=0.6, flavor="igraph", n_iterations=2, directed=False)
+sc.tl.paga(sub, groups="leiden")
+sc.pl.paga(sub, threshold=0.1, show=False)             # keep as a QC artifact
+sc.tl.umap(sub, init_pos="paga", random_state=0)
+
+root_cluster = "3"                                     # justified by marker evidence
+sub.uns["iroot"] = int(np.flatnonzero(sub.obs["leiden"] == root_cluster)[0])
+sc.tl.diffmap(sub, n_comps=15)
+sc.tl.dpt(sub, n_dcs=10)
+```
+
+Deliver: UMAP coloured by `dpt_pseudotime`, PAGA graph, and a heatmap of genes ordered by pseudotime (`sc.pl.heatmap(sub[np.argsort(sub.obs.dpt_pseudotime)], var_names=genes, groupby=None)` or bin cells into 20 pseudotime bins and average). Pseudotime is unitless; never call it "hours" unless calibrated against real time points.
+
+## Alternatives (install on request)
+
+| Tool | Spec | Use when |
+|------|------|----------|
+| Slingshot (R) | `bioconductor-slingshot` (macOS) | Branching lineages with principal curves; reviewers in developmental biology expect it |
+| Monocle 3 (R) | not on conda-forge/bioconda in full — install is fragile; discourage | |
+| scVelo / CellRank | `scvelo`, `cellrank` (python) | Only with spliced/unspliced layers from velocyto/kallisto-bustools; ask for the loom |
+| Palantir | `palantir` | Probabilistic fate on diffusion components |
+
+## Reporting
+
+State the subset, root and its justification, method and parameters (`n_neighbors`, `n_dcs`), and show that known early/late markers are monotonic along the inferred axis. A trajectory that contradicts a known marker gradient is wrong, not novel.

--- a/apps/desktop/resources/skills/single-cell-analysis/scripts/qc_thresholds.py
+++ b/apps/desktop/resources/skills/single-cell-analysis/scripts/qc_thresholds.py
@@ -1,0 +1,92 @@
+"""MAD-based per-sample QC outlier detection and pseudobulk aggregation for scanpy.
+
+    exec(open(f"{SKILL_DIR}/scripts/qc_thresholds.py").read())
+    flags = mad_outliers(adata, sample_key="sample")     # adds adata.obs["qc_outlier"]
+    print(qc_summary(adata, sample_key="sample"))        # cells before/after per sample
+    pb = pseudobulk(adata, sample_key="sample", group_key="cell_type", layer="counts")
+    # pb.counts: genes x (sample|cell_type) ; pb.meta: metadata per pseudobulk column
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+import scipy.sparse as sp
+
+
+def _is_outlier(x: pd.Series, nmads: float) -> pd.Series:
+    med = np.median(x)
+    mad = np.median(np.abs(x - med)) * 1.4826
+    if mad == 0:
+        return pd.Series(False, index=x.index)
+    return (x < med - nmads * mad) | (x > med + nmads * mad)
+
+
+def mad_outliers(adata, sample_key: str | None = None, nmads_counts: float = 5.0,
+                 nmads_genes: float = 5.0, nmads_mt: float = 3.0, mt_hard_cap: float = 20.0) -> pd.Series:
+    """Flag cells as outliers per sample (sc-best-practices rule): |log1p counts| or
+    |log1p genes| beyond `nmads_*` MADs, or mito % beyond `nmads_mt` MADs above the
+    median *or* above `mt_hard_cap`. Writes adata.obs["qc_outlier"] and returns it."""
+    obs = adata.obs
+    required = {"log1p_total_counts", "log1p_n_genes_by_counts", "pct_counts_mt"}
+    missing = required - set(obs.columns)
+    if missing:
+        raise ValueError(f"run sc.pp.calculate_qc_metrics(qc_vars=['mt'], log1p=True) first; missing {missing}")
+    groups = [obs.index] if sample_key is None else [idx for _, idx in obs.groupby(sample_key, observed=True).groups.items()]
+    flag = pd.Series(False, index=obs.index)
+    for idx in groups:
+        sub = obs.loc[idx]
+        f = _is_outlier(sub["log1p_total_counts"], nmads_counts) | _is_outlier(sub["log1p_n_genes_by_counts"], nmads_genes)
+        mt = sub["pct_counts_mt"]
+        med = np.median(mt); mad = np.median(np.abs(mt - med)) * 1.4826
+        f |= (mt > med + nmads_mt * mad) | (mt > mt_hard_cap)
+        flag.loc[idx] = f
+    adata.obs["qc_outlier"] = flag.values
+    return flag
+
+
+def qc_summary(adata, sample_key: str = "sample", flag_key: str = "qc_outlier") -> pd.DataFrame:
+    """Cells per sample before/after removing flagged cells, with medians of key metrics."""
+    obs = adata.obs
+    g = obs.groupby(sample_key, observed=True)
+    out = pd.DataFrame({
+        "cells_before": g.size(),
+        "cells_flagged": g[flag_key].sum().astype(int),
+    })
+    out["cells_after"] = out["cells_before"] - out["cells_flagged"]
+    out["pct_removed"] = (100 * out["cells_flagged"] / out["cells_before"]).round(1)
+    kept = obs[~obs[flag_key]].groupby(sample_key, observed=True)
+    out["median_counts"] = kept["total_counts"].median().round(0)
+    out["median_genes"] = kept["n_genes_by_counts"].median().round(0)
+    out["median_pct_mt"] = kept["pct_counts_mt"].median().round(2)
+    return out
+
+
+@dataclass
+class Pseudobulk:
+    counts: pd.DataFrame   # genes x pseudobulk columns (integer sums)
+    meta: pd.DataFrame     # one row per column: sample, group, n_cells + sample-level covariates
+
+
+def pseudobulk(adata, sample_key: str, group_key: str, layer: str = "counts",
+               min_cells: int = 10, covariates: list[str] | None = None) -> Pseudobulk:
+    """Sum raw counts per (sample, group). Columns with < min_cells cells are dropped.
+    The result feeds pyDESeq2 directly: DeseqDataSet(counts=pb.counts.T, metadata=pb.meta, ...)."""
+    X = adata.layers[layer] if layer else adata.X
+    if not sp.issparse(X):
+        X = sp.csr_matrix(X)
+    key = adata.obs[sample_key].astype(str) + "|" + adata.obs[group_key].astype(str)
+    cats = pd.Categorical(key)
+    indicator = sp.csr_matrix((np.ones(len(cats)), (cats.codes, np.arange(len(cats)))), shape=(len(cats.categories), len(cats)))
+    sums = indicator @ X                                  # pseudobulk x genes
+    counts = pd.DataFrame(np.asarray(sums.todense()).T.round().astype(int), index=adata.var_names, columns=cats.categories)
+    n_cells = pd.Series(np.asarray(indicator.sum(axis=1)).ravel(), index=cats.categories)
+    meta = pd.DataFrame({"n_cells": n_cells})
+    meta["sample"] = [c.split("|")[0] for c in meta.index]
+    meta["group"] = [c.split("|", 1)[1] for c in meta.index]
+    if covariates:
+        sample_level = adata.obs[[sample_key] + covariates].drop_duplicates(sample_key).set_index(sample_key)
+        meta = meta.join(sample_level, on="sample")
+    keep = meta["n_cells"] >= min_cells
+    return Pseudobulk(counts=counts.loc[:, keep], meta=meta.loc[keep])

--- a/apps/desktop/resources/skills/survival-analysis/SKILL.md
+++ b/apps/desktop/resources/skills/survival-analysis/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: survival-analysis
+description: "Time-to-event analysis with lifelines (Python, shipped) or survival + survminer (R, shipped) — Kaplan–Meier curves with risk tables and log-rank tests, median survival with CIs, Cox proportional-hazards regression with hazard ratios and forest plots, proportional-hazards checking (Schoenfeld residuals), stratified and time-varying Cox, competing risks (cumulative incidence, Fine–Gray), parametric AFT models, landmark analysis, and sample-size for a log-rank design. Use whenever data has a time and an event/censoring column, or a user mentions survival, prognosis, hazard ratio, censoring, TCGA clinical data, or a biomarker's effect on outcome. Trigger terms: 生存分析、KM 曲线、Kaplan-Meier、log-rank、Cox 回归、风险比、HR、删失、预后、无进展生存、PFS、OS、竞争风险、森林图."
+license: MIT license
+metadata:
+  version: "1.0"
+  skill-author: PaperMachine community
+---
+
+# Survival Analysis
+
+Run time-to-event analyses through `run_python` (lifelines) or `run_r` (survival, survminer), and write every curve, forest plot, and result table to `SCIENCE_ARTIFACT_DIR`. What a clinical reviewer checks: the event and censoring definitions are stated, the number at risk is shown under every curve, hazard ratios come with CIs and the proportional-hazards assumption was actually tested, and dichotomizing a continuous biomarker at a data-driven "optimal" cutpoint was either avoided or penalized and disclosed.
+
+## Installation
+
+Shipped: `lifelines`, `r-survival`, `r-survminer`, `r-broom`, `r-ggpubr`. Extras through `install_science_packages`:
+
+| Need | Language | Spec |
+|------|----------|------|
+| Competing risks in R (Fine–Gray, CIF) | r | `r-cmprsk`, `r-tidycmprsk` |
+| Time-dependent ROC / C-index over time | r | `r-timeroc`, `r-pec`; python: `scikit-survival` (conda-forge, all platforms) |
+| Optimal-cutpoint with correction | r | `r-maxstat` (used by `survminer::surv_cutpoint`) |
+| Restricted mean survival time | r | `r-survrm2` |
+| Publication forest plots | r | `r-forestmodel` or `r-forestplot`; python: matplotlib (see `scripts/km_cox.py`) |
+
+Compatibility traps: `lifelines` `CoxPHFitter.print_summary()` reports `exp(coef)` = HR; the columns are `coef, exp(coef), se(coef), coef lower 95%, coef upper 95%, exp(coef) lower 95%, exp(coef) upper 95%, z, p`. `KaplanMeierFitter.median_survival_time_` returns `inf` when the curve never crosses 0.5 — report "not reached", not infinity. In R, `survfit` with `Surv(time, status)` expects `status` coded `1 = event, 0 = censored` (or `2/1`); a `TRUE/FALSE` event column works, a character column does not. `ggsurvplot()` returns a list — save with `ggsave(path, print(p))` or extract `p$plot` (the risk table is a second grob; use `survminer::arrange_ggsurvplots` or `png(); print(p); dev.off()`).
+
+## Workflow
+
+1. **Define time, event, and origin.** Time unit (days → months by /30.44 when asked), what counts as an event (death of any cause = OS; progression or death = PFS), what is censored (alive at last follow-up, lost to follow-up), and the start of follow-up (diagnosis, surgery, randomization). Print n, events, censored, median follow-up by **reverse Kaplan–Meier** (`KaplanMeierFitter().fit(T, 1-E)`), and check for zero/negative times and events after censoring dates.
+2. **Describe.** Table of covariates by group (n, %, median/IQR). Numbers at risk at fixed time points.
+3. **Kaplan–Meier.** `KaplanMeierFitter` per group with 95 % CI bands, censor ticks, a risk table below (`lifelines.plotting.add_at_risk_counts`), median survival with CI (`median_survival_times(kmf.confidence_interval_)`), and 1/3/5-year survival estimates with CI. Log-rank (`lifelines.statistics.logrank_test` / `multivariate_logrank_test`) for the overall comparison; pairwise log-rank with Holm/BH correction for > 2 groups. `scripts/km_cox.py::km_plot` draws the standard figure; declare its PNG in `raster_artifacts` and `annotate_artifact` it.
+4. **Cox regression.** Univariable Cox for each candidate covariate (table: HR, 95 % CI, p, n, events), then a multivariable model with covariates chosen **a priori** (clinical knowledge, not univariable p < 0.1 screening, unless the user insists — then label it exploratory). Rule of thumb: ≥ 10 events per covariate. Report HR, 95 % CI, p, concordance index, and a forest plot. Continuous covariates stay continuous; check functional form (martingale residuals or a restricted cubic spline via `patsy`/`rms`) before assuming linearity.
+5. **Check proportional hazards.** `cph.check_assumptions(df, p_value_threshold=0.05, show_plots=True)` (scaled Schoenfeld) or `survival::cox.zph(fit)` with `ggcoxzph`. If violated for a covariate: stratify on it (`strata=`), add a time interaction, split follow-up at a landmark, or report RMST difference instead — and say which.
+6. **Extensions when the question needs them.** Competing risks (death from other causes when the endpoint is cancer-specific death): cumulative incidence with `lifelines.AalenJohansenFitter` or `cmprsk::cuminc`, Fine–Gray sub-distribution HR with `cmprsk::crr`; 1 − KM overestimates the event risk here — say so. Time-varying covariates: long format + `CoxTimeVaryingFitter` / `survival::tmerge`. Landmark analysis for treatment received after baseline (immortal-time bias). Parametric AFT (`WeibullAFTFitter`, `LogNormalAFTFitter`) when extrapolation or a time-ratio interpretation is wanted; compare by AIC.
+7. **Biomarker cutpoints.** Prefer continuous HR per SD or per unit, tertiles/quartiles, or a median split stated in advance. If an optimal cutpoint is requested: `survminer::surv_cutpoint` (maximally selected rank statistics with a corrected p) and state that the p-value is corrected for cutpoint selection; validate on a held-out set if available.
+8. **Report.** n, events, median follow-up; KM medians and time-point survival with CI; log-rank χ² and p; univariable and multivariable HR tables; PH test results and remedies; software versions (`lifelines.__version__`, `packageVersion("survival")`).
+
+## Integrity rules
+
+1. **Every KM figure has a risk table and censor marks.** A curve without numbers at risk hides where the estimate becomes unreliable.
+2. **Never dichotomize a continuous variable at the cutpoint with the smallest p** without a selection-corrected test and disclosure.
+3. **Hazard ratios are relative, not absolute.** Pair the HR with absolute differences (median survival or 5-year survival difference) in the write-up.
+4. **A non-proportional hazard makes a single HR an average over follow-up** — report the check, and if violated, report a time-stratified or RMST alternative.
+5. **Competing events are not censoring.** Use cumulative incidence when the competing event prevents the endpoint.
+6. **Immortal time**: exposure defined after baseline needs a landmark or time-varying model.
+7. **Multiple testing** across many biomarkers or subgroups is corrected and reported; subgroup forest plots include the interaction p, not just per-subgroup p.
+
+## Quick reference
+
+```python
+from lifelines import KaplanMeierFitter, CoxPHFitter
+from lifelines.statistics import logrank_test, multivariate_logrank_test
+from lifelines.utils import median_survival_times
+
+kmf = KaplanMeierFitter().fit(df["time"], df["event"], label="All")
+kmf.median_survival_time_, median_survival_times(kmf.confidence_interval_)
+kmf.predict([12, 36, 60])                                      # survival at time points
+lr = multivariate_logrank_test(df["time"], df["group"], df["event"]); lr.test_statistic, lr.p_value
+
+cph = CoxPHFitter().fit(df[["time","event","age","sex","stage"]], "time", "event", formula="age + C(sex) + C(stage)")
+cph.summary[["exp(coef)","exp(coef) lower 95%","exp(coef) upper 95%","p"]]; cph.concordance_index_
+cph.check_assumptions(df, p_value_threshold=0.05)
+```
+
+```r
+library(survival); library(survminer)
+fit <- survfit(Surv(time, event) ~ group, data = df)
+p <- ggsurvplot(fit, data = df, risk.table = TRUE, pval = TRUE, conf.int = TRUE, surv.median.line = "hv",
+                xlab = "Months", break.time.by = 12, legend.title = "")
+png(file.path(Sys.getenv("SCIENCE_ARTIFACT_DIR"), "km_by_group.png"), width = 1800, height = 1500, res = 220); print(p); dev.off()
+survdiff(Surv(time, event) ~ group, data = df)
+cox <- coxph(Surv(time, event) ~ age + sex + stage, data = df); summary(cox); cox.zph(cox)
+broom::tidy(cox, exponentiate = TRUE, conf.int = TRUE)
+```
+
+Files: `scripts/km_cox.py` (`km_plot`, `cox_table`, `forest_plot`, `follow_up_summary`), `references/methods_and_reporting.md` (sample size for log-rank, RMST, competing risks, reporting template).

--- a/apps/desktop/resources/skills/survival-analysis/references/methods_and_reporting.md
+++ b/apps/desktop/resources/skills/survival-analysis/references/methods_and_reporting.md
@@ -1,0 +1,40 @@
+# Survival methods beyond KM/Cox, and how to report
+
+## Sample size for a two-arm log-rank comparison (Schoenfeld)
+
+Required events: `d = (z_{1-α/2} + z_{1-β})² / (p₁ p₂ (ln HR)²)` with allocation fractions p₁, p₂ (0.5/0.5 → denominator 0.25).
+Example: HR 0.7, α 0.05 two-sided, power 0.8 → `d = (1.96 + 0.842)² / (0.25 × 0.1272) ≈ 247` events. Convert to patients with the expected event probability by the analysis time (from the control arm's KM: `P(event) = 1 − S(t)` averaged over accrual). lifelines has no built-in; compute it directly and show the formula. In R, `powerSurvEpi::ssizeCT.default` or `gsDesign::nSurv` if installed.
+
+## Restricted mean survival time (RMST)
+
+Area under the KM curve up to τ (choose τ ≤ minimum of the arms' maximum follow-up, state it). Difference in RMST is an absolute, assumption-free effect size — the recommended alternative when proportional hazards fail (crossing curves, delayed separation in immunotherapy trials).
+Python: `lifelines.utils.restricted_mean_survival_time(kmf, t=τ)`; R: `survRM2::rmst2(time, status, arm, tau=τ)` returns the difference with CI and p.
+
+## Competing risks
+
+| Quantity | Estimator | Interpretation |
+|----------|-----------|----------------|
+| Cumulative incidence of event k | Aalen–Johansen (`lifelines.AalenJohansenFitter(event_of_interest=k)`, `cmprsk::cuminc`) | Probability of event k by time t in the presence of other events — the clinically meaningful risk |
+| 1 − KM treating competing events as censored | KM | Overestimates; a hypothetical world where competing events cannot happen |
+| Cause-specific HR | Cox on event k, competing events censored | Etiological effect on the hazard of k among those still at risk |
+| Sub-distribution HR (Fine–Gray) | `cmprsk::crr`, `tidycmprsk::crr` | Effect on the cumulative incidence; used for prediction |
+
+Report both cause-specific and sub-distribution models when the question is prognostic; say which is which.
+
+## Time-varying covariates and immortal time
+
+Exposures that begin after baseline (a treatment started mid-follow-up, a transplant, a response) make early follow-up "immortal" for the exposed group. Fixes: **landmark analysis** (restart the clock at a fixed time, classify exposure by that time, exclude earlier events) or a **time-varying Cox** in counting-process format (`start, stop, event` rows; `survival::tmerge` or `lifelines.CoxTimeVaryingFitter`). Never compare "responders vs non-responders" from baseline without one of these.
+
+## Parametric models
+
+`WeibullAFTFitter`, `LogNormalAFTFitter`, `LogLogisticAFTFitter` (`survreg(dist=)` in R). Coefficients are log time ratios: `exp(coef) = 1.3` means 30 % longer expected survival. Choose by AIC and by a Q–Q/Cox–Snell residual check. Weibull with shape 1 is exponential; report the shape.
+
+## Cutpoint selection
+
+`survminer::surv_cutpoint(df, time, event, variables, minprop = 0.1)` uses maximally selected rank statistics with the Hothorn–Lausen correction. Report the corrected p and the number of candidate cutpoints; an "optimal" cutpoint found in the discovery cohort overfits — validate externally or with bootstrap.
+
+## Reporting template
+
+> Median follow-up was X months (reverse KM). Among N patients, E events occurred. Median OS was A months (95 % CI a₁–a₂) in group 1 versus B months (95 % CI b₁–b₂) in group 2 (log-rank p = 0.0xx); 3-year OS was P₁ % vs P₂ %. In multivariable Cox regression adjusting for age, sex, and stage, group 2 was associated with a hazard ratio of HR (95 % CI l–u, p = 0.0xx); the concordance index was C. The proportional-hazards assumption was assessed by scaled Schoenfeld residuals (global p = 0.xx) [and was violated for covariate Z, which was therefore entered as a stratification factor]. Analyses used lifelines v… / R survival v….
+
+Figures: KM with risk table (censor marks, CI bands), forest plot of the multivariable model with HR text, and — when non-proportional — a plot of the scaled Schoenfeld residuals or the RMST comparison.

--- a/apps/desktop/resources/skills/survival-analysis/scripts/km_cox.py
+++ b/apps/desktop/resources/skills/survival-analysis/scripts/km_cox.py
@@ -1,0 +1,116 @@
+"""Kaplan–Meier figure with risk table, Cox tables, and a matplotlib forest plot.
+
+    exec(open(f"{SKILL_DIR}/scripts/km_cox.py").read())
+    print(follow_up_summary(df, "time", "event"))
+    fig, stats = km_plot(df, "time", "event", group="arm", time_label="Months", timepoints=[12, 36, 60])
+    fig.savefig(f"{SCIENCE_ARTIFACT_DIR}/km_by_arm.png", dpi=150, bbox_inches="tight")
+    uni, multi, cph = cox_table(df, "time", "event", covariates=["age", "C(sex)", "C(stage)"])
+    ffig = forest_plot(multi, title="Multivariable Cox"); ffig.savefig(f"{SCIENCE_ARTIFACT_DIR}/forest.png", dpi=150, bbox_inches="tight")
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from lifelines import KaplanMeierFitter, CoxPHFitter
+from lifelines.plotting import add_at_risk_counts
+from lifelines.statistics import multivariate_logrank_test, pairwise_logrank_test
+from lifelines.utils import median_survival_times
+
+
+def follow_up_summary(df: pd.DataFrame, time: str, event: str) -> pd.Series:
+    """n, events, censored, median follow-up by reverse Kaplan–Meier, and basic time checks."""
+    t, e = df[time].astype(float), df[event].astype(int)
+    rkm = KaplanMeierFitter().fit(t, 1 - e)
+    return pd.Series({
+        "n": len(df), "events": int(e.sum()), "censored": int((1 - e).sum()),
+        "median_follow_up_reverse_km": rkm.median_survival_time_,
+        "min_time": t.min(), "max_time": t.max(),
+        "nonpositive_times": int((t <= 0).sum()), "missing_time_or_event": int(df[[time, event]].isna().any(axis=1).sum()),
+    })
+
+
+def km_plot(df: pd.DataFrame, time: str, event: str, group: str | None = None, time_label: str = "Time",
+            timepoints: list[float] | None = None, ci: bool = True, title: str | None = None):
+    """KM curves (per group) with CI bands, censor ticks, risk table, log-rank p in the legend.
+    Returns (fig, stats) where stats holds medians with CI, time-point survival, and log-rank results."""
+    fig, ax = plt.subplots(figsize=(7.5, 6))
+    fitters, rows, tp_rows = [], [], []
+    groups = [(None, df)] if group is None else list(df.groupby(group, observed=True))
+    for name, sub in groups:
+        label = "All" if name is None else f"{name} (n={len(sub)})"
+        kmf = KaplanMeierFitter().fit(sub[time], sub[event], label=label)
+        kmf.plot_survival_function(ax=ax, ci_show=ci, show_censors=True, censor_styles={"ms": 5, "marker": "|"})
+        fitters.append(kmf)
+        med = kmf.median_survival_time_
+        med_ci = median_survival_times(kmf.confidence_interval_).iloc[0].tolist()
+        rows.append({"group": "All" if name is None else name, "n": len(sub), "events": int(sub[event].sum()),
+                     "median": "not reached" if np.isinf(med) else round(med, 2),
+                     "median_lower95": "NR" if np.isinf(med_ci[0]) else round(med_ci[0], 2),
+                     "median_upper95": "NR" if np.isinf(med_ci[1]) else round(med_ci[1], 2)})
+        if timepoints:
+            sf = kmf.survival_function_at_times(timepoints).values
+            ci_df = kmf.confidence_interval_
+            for tpt, s in zip(timepoints, sf):
+                idx = ci_df.index[ci_df.index <= tpt].max() if (ci_df.index <= tpt).any() else ci_df.index[0]
+                lo, hi = ci_df.loc[idx].tolist()
+                tp_rows.append({"group": "All" if name is None else name, "time": tpt, "survival": round(s, 3),
+                                "lower95": round(lo, 3), "upper95": round(hi, 3)})
+    stats = {"medians": pd.DataFrame(rows), "timepoints": pd.DataFrame(tp_rows) if tp_rows else None}
+    if group is not None and len(groups) > 1:
+        lr = multivariate_logrank_test(df[time], df[group], df[event])
+        stats["logrank"] = {"statistic": lr.test_statistic, "p": lr.p_value, "df": len(groups) - 1}
+        if len(groups) > 2:
+            stats["pairwise_logrank"] = pairwise_logrank_test(df[time], df[group], df[event]).summary
+        ptxt = f"log-rank p = {lr.p_value:.3f}" if lr.p_value >= 0.001 else "log-rank p < 0.001"
+        ax.text(0.02, 0.05, ptxt, transform=ax.transAxes, fontsize=10)
+    ax.set_ylim(0, 1.02); ax.set_xlim(left=0)
+    ax.set_xlabel(time_label); ax.set_ylabel("Survival probability")
+    ax.set_title(title or ("Kaplan–Meier estimate" if group is None else f"Kaplan–Meier by {group}"))
+    ax.grid(alpha=0.25)
+    ax.legend(loc="upper right", frameon=False)
+    add_at_risk_counts(*fitters, ax=ax, rows_to_show=["At risk"])
+    fig.tight_layout()
+    return fig, stats
+
+
+def cox_table(df: pd.DataFrame, time: str, event: str, covariates: list[str], penalizer: float = 0.0):
+    """Univariable Cox for each covariate and one multivariable model. `covariates` use lifelines
+    formula syntax, e.g. ["age", "C(sex)", "C(stage)"]. Returns (uni_df, multi_df, fitted_multivariable_cph)."""
+    def tidy(cph: CoxPHFitter, model: str) -> pd.DataFrame:
+        s = cph.summary
+        out = pd.DataFrame({
+            "term": s.index, "HR": s["exp(coef)"].round(3),
+            "lower95": s["exp(coef) lower 95%"].round(3), "upper95": s["exp(coef) upper 95%"].round(3),
+            "p": s["p"].round(4), "model": model, "n": cph._n_examples, "events": int(cph.event_observed.sum()),
+        })
+        return out.reset_index(drop=True)
+    uni = []
+    for cov in covariates:
+        cph = CoxPHFitter(penalizer=penalizer).fit(df, time, event, formula=cov)
+        uni.append(tidy(cph, "univariable"))
+    multi_cph = CoxPHFitter(penalizer=penalizer).fit(df, time, event, formula=" + ".join(covariates))
+    multi = tidy(multi_cph, "multivariable")
+    multi.attrs["concordance"] = multi_cph.concordance_index_
+    return pd.concat(uni, ignore_index=True), multi, multi_cph
+
+
+def forest_plot(table: pd.DataFrame, title: str = "Cox proportional hazards", label_col: str = "term"):
+    """Forest plot of HR with 95% CI on a log axis from a `cox_table` output frame."""
+    t = table.iloc[::-1].reset_index(drop=True)
+    fig, ax = plt.subplots(figsize=(7.5, 0.5 * len(t) + 1.5))
+    y = np.arange(len(t))
+    ax.errorbar(t["HR"], y, xerr=[t["HR"] - t["lower95"], t["upper95"] - t["HR"]], fmt="s", color="black",
+                ecolor="black", capsize=3, markersize=6)
+    ax.axvline(1, ls="--", color="grey", lw=1)
+    ax.set_xscale("log")
+    ax.set_yticks(y); ax.set_yticklabels(t[label_col])
+    ax.set_xlabel("Hazard ratio (95% CI, log scale)")
+    for yi, (hr, lo, hi, p) in enumerate(zip(t["HR"], t["lower95"], t["upper95"], t["p"])):
+        ptxt = "<0.001" if p < 0.001 else f"{p:.3f}"
+        ax.text(1.02, yi, f"{hr:.2f} ({lo:.2f}–{hi:.2f})  p={ptxt}", transform=ax.get_yaxis_transform(), va="center", fontsize=8.5)
+    ax.set_title(title, loc="left")
+    fig.subplots_adjust(right=0.7)
+    return fig

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -138,26 +138,43 @@ async function desktopHostConfig(): Promise<DesktopHostConfig> {
   return parseDesktopHostConfig(JSON.parse(await readFile(join(resourceRoot(), 'host.json'), 'utf8')))
 }
 
-/** The one environment this build ships; disciplines are added as further declarations. */
-const SHIPPED_ENVIRONMENT_ID = 'general'
+/**
+ * Every discipline declaration this build ships, in the order onboarding
+ * lists them. `general` stays first: it is the package set the custom editor
+ * starts from and the fallback source list when no applied declaration can
+ * be resolved (see {@link writeRuntimeOverlay}).
+ */
+const SHIPPED_ENVIRONMENT_IDS = ['general', 'biology'] as const
+type ShippedEnvironmentId = (typeof SHIPPED_ENVIRONMENT_IDS)[number]
+const STANDARD_ENVIRONMENT_ID: ShippedEnvironmentId = 'general'
 
-/** Read the shipped declaration; the standard package set onboarding offers and the custom editor starts from. */
-async function shippedDeclaration(): Promise<EnvironmentDeclaration> {
+/** Read one shipped declaration by id. */
+async function readShippedDeclaration(id: ShippedEnvironmentId): Promise<EnvironmentDeclaration> {
   return parseEnvironmentDeclaration(
-    JSON.parse(await readFile(join(resourceRoot(), 'environments', `${SHIPPED_ENVIRONMENT_ID}.json`), 'utf8')),
+    JSON.parse(await readFile(join(resourceRoot(), 'environments', `${id}.json`), 'utf8')),
   )
+}
+
+/** Every shipped declaration, in onboarding order. */
+async function shippedDeclarations(): Promise<EnvironmentDeclaration[]> {
+  return Promise.all(SHIPPED_ENVIRONMENT_IDS.map(readShippedDeclaration))
+}
+
+/** The standard (`general`) declaration; the package set the custom editor starts from. */
+async function shippedDeclaration(): Promise<EnvironmentDeclaration> {
+  return readShippedDeclaration(STANDARD_ENVIRONMENT_ID)
 }
 
 /**
  * Every declaration this launch can resolve an applied environment against:
- * the shipped one, plus the user's own package set once they have authored
+ * the shipped ones, plus the user's own package set once they have authored
  * one. The custom declaration must be included for `resolveDisciplineStatus`
  * to report `current` for a working custom install rather than
  * `unknown-discipline`.
  */
 async function declarations(dshHome: string): Promise<readonly EnvironmentDeclaration[]> {
   const custom = await readCustomDeclaration(desktopEnvironmentsRoot(dshHome))
-  return [await shippedDeclaration(), ...(custom === undefined ? [] : [custom])]
+  return [...(await shippedDeclarations()), ...(custom === undefined ? [] : [custom])]
 }
 
 /** The bundled micromamba executable for this machine, shared by provisioning and the Host's package installer. */
@@ -246,7 +263,9 @@ async function startProvisioning(dshHome: string, declaration: EnvironmentDeclar
         event: 'environment.installed',
         sourceId: published.sourceId,
         durationMs: Date.now() - startedAt,
-        environmentId: declaration.id === CUSTOM_ENVIRONMENT_ID ? 'custom' : 'general',
+        // Shipped discipline ids are a closed, build-time vocabulary and carry
+        // no user content; `custom` never reports the user's package list.
+        environmentId: declaration.id === CUSTOM_ENVIRONMENT_ID ? 'custom' : (declaration.id as 'general' | 'biology'),
       })
       await openWorkspace()
     } catch (error) {
@@ -266,22 +285,25 @@ async function startProvisioning(dshHome: string, declaration: EnvironmentDeclar
 }
 
 /**
- * Write the Host overlay for `binding`. The install channels are the shipped
- * declaration's sources reordered to start from the bound source, flattened
- * to their channel URLs, so a package install first tries the mirror the
- * environment itself came from; a bound source id the shipped declaration no
- * longer lists (a later build renamed its sources) keeps the declaration's
- * own order, the same rule `orderSourcesFrom` applies to provisioning's
- * preferred source. A custom package set shares the shipped sources
- * unchanged (`buildCustomDeclaration`), so the shipped declaration is the
- * one source list for both.
+ * Write the Host overlay for `binding`. The install channels are the
+ * applied discipline declaration's sources reordered to start from the bound source,
+ * flattened to their channel URLs, so a package install first tries the
+ * mirror the environment itself came from — and, for a discipline such as
+ * `biology` whose sources list a second channel (bioconda) beside
+ * conda-forge, so `install_science_packages` can reach that channel too.
+ * When no applied declaration resolves (a binding written by an older
+ * build, or a custom set), the standard declaration's sources are used, the
+ * previous behaviour.
  * @param dshHome - the Harness home the overlay is written into.
  * @param binding - the bound environment.
  * @returns the overlay path passed to the Host as `--patch`.
  */
 async function writeRuntimeOverlay(dshHome: string, binding: EnvironmentBinding): Promise<string> {
   const overlay = join(dshHome, 'desktop-science.cordis.patch.yml')
-  const sources = orderSourcesFrom((await shippedDeclaration()).sources, binding.sourceId)
+  const applied = await provisioner(dshHome).applied()
+  const known = await declarations(dshHome)
+  const declaration = (applied === undefined ? undefined : known.find(item => item.id === applied.id)) ?? (await shippedDeclaration())
+  const sources = orderSourcesFrom(declaration.sources, binding.sourceId)
   await writeFile(overlay, renderDesktopRuntimeOverlay({
     ...(binding.pythonPrefix === undefined ? {} : { pythonPrefix: binding.pythonPrefix }),
     ...(binding.rPrefix === undefined ? {} : { rPrefix: binding.rPrefix }),

--- a/apps/desktop/src/onboarding.ts
+++ b/apps/desktop/src/onboarding.ts
@@ -196,6 +196,35 @@ function dismissConfirm(): void {
   confirm.hidden = true
 }
 
+const offeredEnvironments = document.querySelector<HTMLDivElement>('#offered-environments')
+
+function renderOfferedEnvironments(
+  environments: readonly OfferedEnvironment[],
+  selectedId: string | undefined,
+  onSelect: (env: OfferedEnvironment) => void,
+): void {
+  if (!offeredEnvironments) return
+  offeredEnvironments.replaceChildren()
+  for (const env of environments) {
+    const label = document.createElement('label')
+    label.className = 'choice'
+    const input = document.createElement('input')
+    input.type = 'radio'
+    input.name = 'discipline-environment'
+    input.value = env.id
+    input.checked = env.id === selectedId
+    input.addEventListener('change', () => { onSelect(env) })
+    const copy = document.createElement('span')
+    const strong = document.createElement('strong')
+    strong.textContent = env.name
+    const small = document.createElement('small')
+    small.textContent = `${String(env.packages.length)} 个包 · 约 ${formatBytes(env.estimatedDownloadBytes)} · ${String(env.packages.length)} packages, ~${formatBytes(env.estimatedDownloadBytes)}`
+    copy.append(strong, small)
+    label.append(input, copy)
+    offeredEnvironments.append(label)
+  }
+}
+
 async function loadEnvironments(): Promise<void> {
   provision.disabled = true
   try {
@@ -203,10 +232,16 @@ async function loadEnvironments(): Promise<void> {
       window.desktopOnboarding.environments(),
       window.desktopOnboarding.currentEnvironment(),
     ])
-    const shipped = offered[0]
-    if (shipped === undefined) throw new Error(ENVIRONMENTS_UNAVAILABLE_MESSAGE)
+    const initial = offered[0]
+    if (initial === undefined) throw new Error(ENVIRONMENTS_UNAVAILABLE_MESSAGE)
     if (applied !== undefined) renderCurrent(applied)
-    renderStandard(shipped)
+    if (offered.length > 1 && offeredEnvironments) {
+      renderOfferedEnvironments(offered, initial.id, (selected) => {
+        renderStandard(selected)
+      })
+      offeredEnvironments.hidden = false
+    }
+    renderStandard(initial)
     provision.disabled = false
   } catch (error) {
     installSummary.textContent = error instanceof Error ? error.message : String(error)

--- a/apps/desktop/src/telemetry.ts
+++ b/apps/desktop/src/telemetry.ts
@@ -40,7 +40,7 @@ export type TelemetryEventInput =
     /** The package source that succeeded (`tuna`/`ustc`/`official`, or a custom declaration's chosen source id). */
     readonly sourceId: string
     readonly durationMs: number
-    readonly environmentId: 'general' | 'custom'
+    readonly environmentId: 'general' | 'biology' | 'custom'
   }
   | {
     readonly event: 'environment.install-failed'

--- a/apps/desktop/tests/bundled-skills.spec.ts
+++ b/apps/desktop/tests/bundled-skills.spec.ts
@@ -35,13 +35,19 @@ async function listCandidates(provider: FileSystemSkillProvider): Promise<readon
 }
 
 describe('desktop bundled default Science skills', () => {
-  it('discovers exactly the three shipped skills, each named for its directory', async () => {
+  it('discovers exactly the shipped skills, each named for its directory', async () => {
     const candidates = await listCandidates(bundledSkillsProvider())
 
     expect(candidates.map(candidate => candidate.name).sort()).toEqual([
+      'bioassay-and-dose-response',
+      'bulk-rnaseq-analysis',
+      'ecology-and-diversity',
       'scientific-visualization',
       'scientific-writing',
+      'sequence-analysis',
+      'single-cell-analysis',
       'statistical-analysis',
+      'survival-analysis',
     ])
     for (const candidate of candidates) {
       expect(candidate.source).toBe('bundled')

--- a/apps/desktop/tests/environment-declaration.spec.ts
+++ b/apps/desktop/tests/environment-declaration.spec.ts
@@ -34,6 +34,17 @@ describe('desktop environment declarations', () => {
     expect(parsed.healthChecks.map(check => check.language)).toEqual(['python', 'r'])
   })
 
+  it('accepts the shipped biology declaration as a superset of general', async () => {
+    const general = parseEnvironmentDeclaration(JSON.parse(await readFile(join(resources, 'general.json'), 'utf8')))
+    const biology = parseEnvironmentDeclaration(JSON.parse(await readFile(join(resources, 'biology.json'), 'utf8')))
+    expect(biology.id).toBe('biology')
+    expect(biology.healthChecks.map(check => check.language)).toEqual(['python', 'r'])
+    const generalNames = general.packages.map(spec => spec.split('=')[0])
+    const biologyNames = biology.packages.map(spec => spec.split('=')[0])
+    expect(biologyNames).toEqual(expect.arrayContaining(generalNames))
+    expect(biology.sources.every(s => s.channels.length === 2)).toBe(true)
+  })
+
   it('ships three ordered mirror sources, tuna first, the official channel last', async () => {
     const parsed = parseEnvironmentDeclaration(JSON.parse(await readFile(join(resources, 'general.json'), 'utf8')))
     expect(parsed.sources.map(source => source.id)).toEqual(['tuna', 'ustc', 'official'])

--- a/apps/desktop/tests/onboarding.spec.ts
+++ b/apps/desktop/tests/onboarding.spec.ts
@@ -43,6 +43,7 @@ function setDom(): void {
       <button id="keep-current"></button>
     </section>
     <section id="install">
+      <div id="offered-environments" hidden></div>
       <p id="install-summary"></p>
       <ul id="packages"></ul>
       <details id="advanced"><summary>advanced</summary><textarea id="custom-packages"></textarea></details>
@@ -347,16 +348,38 @@ describe('onboarding install route', () => {
     expect(cancelProvisioning).toHaveBeenCalled()
   })
 
-  it('offers no bind-an-existing-environment route: the bridge exposes only the install methods', async () => {
-    const { bridge } = installBridge()
+  it('renders a radio picker when multiple discipline environments are offered and allows switching', async () => {
+    const BIOLOGY: OfferedEnvironment = {
+      id: 'biology',
+      name: 'Biology',
+      revision: '2026.10.1',
+      packages: ['python=3.13', 'scanpy=1.11', 'biopython=1.85'],
+      estimatedDownloadBytes: 780_000_000,
+      requiredFreeBytes: 8_000_000_000,
+      sources: [
+        { id: 'tuna', name: 'TUNA mirror' },
+        { id: 'official', name: 'Official channel' },
+      ],
+      defaultSourceId: 'tuna',
+    }
+    const { bridge, provision } = installBridge({
+      environments: vi.fn(async () => [STANDARD, BIOLOGY]),
+    })
     await loadOnboarding(bridge)
 
-    expect(Object.keys(bridge).sort()).toEqual([
-      'cancelProvisioning', 'currentEnvironment', 'environments', 'keepCurrentEnvironment', 'onProvisioningProgress',
-      'onboardingStatus', 'provision', 'provisionCustom',
-    ])
-    expect(document.querySelector('#detected')).toBeNull()
-    expect(document.querySelector('#bind')).toBeNull()
-    expect(document.querySelector('#redetect')).toBeNull()
+    const radios = document.querySelectorAll<HTMLInputElement>('input[name="discipline-environment"]')
+    expect(radios.length).toBe(2)
+    expect(radios[0]?.checked).toBe(true)
+    expect(radios[1]?.checked).toBe(false)
+    expect(textOf('#install-summary')).toContain('General science')
+
+    // Switch to Biology
+    radios[1]?.click()
+    radios[1]?.dispatchEvent(new Event('change'))
+    expect(textOf('#install-summary')).toContain('Biology')
+
+    click('#provision')
+    click('#confirm-start')
+    expect(provision).toHaveBeenCalledWith('biology', 'tuna')
   })
 })


### PR DESCRIPTION
## feat(desktop): biology discipline environment + six biology skills

Closes the first item of the README Roadmap ("Discipline environments") for biology.

### What this adds

**1. `biology` environment declaration** — `apps/desktop/resources/environments/biology.json`
- Superset of `general` (nothing is lost when switching), adding Biopython, scanpy/anndata/leidenalg/umap-learn, lifelines, scikit-posthocs; R survival/survminer, vegan, ape/phangorn, pheatmap, ggpubr, rstatix, emmeans, drc.
- Conda-forge-only package set → all three shipped platforms stay supported.
- Each source lists conda-forge **and** bioconda mirrors, so `install_science_packages` can reach Bioconductor on macOS once the overlay derives channels from the applied declaration (below). Bioconductor itself is on-demand, not declared: bioconda has no `win-64` builds.
- ~780 MB download / 8 GB free.

**2. Desktop wiring** — `apps/desktop/src/main.ts` (+ `telemetry.ts` type, onboarding picker)
- `SHIPPED_ENVIRONMENT_IDS = ['general', 'biology']`; `declarations()` returns all shipped + custom.
- `writeRuntimeOverlay` takes `installChannels` from the **applied** declaration, falling back to `general`.
- Telemetry `environmentId` reports the shipped discipline id (closed vocabulary) or `custom`.
- Onboarding lists shipped declarations as a radio group (`general` preselected).

**3. Six bundled biology skills** — `apps/desktop/resources/skills/`
| Skill | Covers |
|---|---|
| `bulk-rnaseq-analysis` | count QC → pyDESeq2/DESeq2/edgeR/limma → volcano/MA/heatmap → ORA/GSEA |
| `single-cell-analysis` | scanpy QC → HVG → PCA → Leiden → UMAP → markers → annotation → pseudobulk DE |
| `sequence-analysis` | Biopython parsing, ORFs, primers, alignment, variants; ape/phangorn ML trees with bootstrap |
| `survival-analysis` | KM + risk table, log-rank, Cox + PH check, competing risks, RMST |
| `bioassay-and-dose-response` | 4PL IC50 with CI, growth curves, ΔΔCt/Pfaffl, standard curves, Z′, MM kinetics |
| `ecology-and-diversity` | rarefaction, alpha/beta diversity, PCoA/NMDS, PERMANOVA + betadisper, dbRDA, taxa bars |

Each skill follows the vendored three's frontmatter/body shape (Chinese trigger terms, `install_science_packages` routing, `SCIENCE_ARTIFACT_DIR` + `raster_artifacts` conventions, integrity rules) and ships first-party `scripts/` and `references/`. Authored in-repo, not vendored — `SOURCES.md` documents why and how to maintain them.

**4. Docs** — Agent Note `.agents/notes/proposed/feature/2026-10-05-biology-discipline-environment-and-skills.md`; README "What is inside" + Roadmap updated; `README.zh.md` paired.

### Not in this PR
- No new Cordis plugin/tool. Biology's extension surface here is data + skills, which the desktop already exposes.
- No bundled gene-set/annotation databases.

### Verification
- [ ] `pnpm run typecheck`, `pnpm run lint`, `pnpm run doc-sync`
- [ ] `apps/desktop` tests: parse `biology.json`; `declarations()` yields two shipped entries; overlay channels follow applied declaration, fall back to `general`
- [ ] macOS arm64 + Windows x64: provision `biology` via TUNA and official; both health checks pass
- [ ] macOS: `install_science_packages r bioconductor-deseq2` succeeds; Windows: fails cleanly with no bioconda candidate
- [ ] Each skill invoked via `/` on a public dataset (airway, pbmc3k, an ASV table, `survival::lung`); declared PNGs captured, CSVs auto-captured
- [ ] Version pins in `biology.json` re-checked with `micromamba search` against conda-forge at PR time
