### PR TITLE
修复 Windows 目录选择器在 Electron 中创建外部 ArrayBuffer 导致的崩溃

### DIFF
--- a/.agents/notes/implemented/bug-fix/2026-09-09-windows-picker-owned-buffer.i18n.yaml
+++ b/.agents/notes/implemented/bug-fix/2026-09-09-windows-picker-owned-buffer.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record (docs/i18n/README.md): the git blob hash of each
+# side as of the last confirmed-consistent state. Both languages carry equal authority;
+# after editing either side, bring the other along and re-record with:
+#   pnpm run verify-translation-pairing --write .agents/notes/implemented/bug-fix/2026-09-09-windows-picker-owned-buffer.md
+2026-09-09-windows-picker-owned-buffer.md: b9d851753c2f3614c08ad5fc84b543624defee16
+2026-09-09-windows-picker-owned-buffer.zh.md: cbb1df4f31d512a69d9d0ec941c14753a15fc154

--- a/.agents/notes/implemented/bug-fix/2026-09-09-windows-picker-owned-buffer.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-09-windows-picker-owned-buffer.md
@@ -1,0 +1,27 @@
+# Agent Note: Windows picker owned buffers
+
+Status: implemented
+
+English | [中文](2026-09-09-windows-picker-owned-buffer.zh.md)
+
+## Problem
+
+PaperMachine 0.1.1 still crashes in `readUtf16` after selecting a folder ([issue #5](https://github.com/SuperJJ007/papermachine/issues/5)). Exact allocation sizing prevents overreads but does not make `koffi.view` compatible with Electron's [V8 memory cage](https://www.electronjs.org/blog/v8-memory-cage), which rejects external ArrayBuffers.
+
+## Decision
+
+The Windows picker copies the COM allocation into `Buffer.alloc` memory using `RtlMoveMemory`, then decodes UTF-16. `lstrlenW` bounds the copy to the string plus its terminating NUL. COM allocation ownership and cleanup remain unchanged.
+
+## Alternatives considered
+
+**Exact-length external view:** still aborts in Electron 43.4.1 with `FATAL ERROR: Error::New napi_get_last_error_info`, including for a valid two-byte empty string allocation.
+
+**Browse-only composition:** bypasses the crash but replaces the native interaction and leaves the native backend broken.
+
+## Verification
+
+The binding tests reject all external views and cover empty, ASCII, CJK, space-containing and surrogate-pair paths. A native `CoTaskMemAlloc` probe under the installed Electron 43.4.1 exits 134 for the view implementation and 0 for the copy implementation. Interactive selection through a rebuilt installer remains a separate acceptance check.
+
+## Consequences
+
+Each selection adds one bounded buffer allocation and memory copy. The picker works with Electron's memory cage without disabling runtime protections or changing the interaction protocol.

--- a/.agents/notes/implemented/bug-fix/2026-09-09-windows-picker-owned-buffer.zh.md
+++ b/.agents/notes/implemented/bug-fix/2026-09-09-windows-picker-owned-buffer.zh.md
@@ -1,0 +1,27 @@
+# Agent Note: Windows 选择器使用自有缓冲区
+
+Status: implemented
+
+[English](2026-09-09-windows-picker-owned-buffer.md) | 中文
+
+## 问题
+
+PaperMachine 0.1.1 在选择文件夹后仍于 `readUtf16` 崩溃（[issue #5](https://github.com/SuperJJ007/papermachine/issues/5)）。精确限定分配长度可以防止越界读取，但无法使 `koffi.view` 兼容 Electron 的 [V8 内存笼](https://www.electronjs.org/blog/v8-memory-cage)，后者拒绝外部 ArrayBuffer。
+
+## 决策
+
+Windows 选择器使用 `RtlMoveMemory` 将 COM 分配的内存复制到 `Buffer.alloc` 创建的内存，再解码 UTF-16。`lstrlenW` 将复制范围限制为字符串及其结尾 NUL。COM 内存的所有权和释放流程保持不变。
+
+## 考虑过的替代方案
+
+**精确长度的外部视图：** 在 Electron 43.4.1 中仍以 `FATAL ERROR: Error::New napi_get_last_error_info` 中止，包括合法的两字节空字符串分配。
+
+**仅使用应用内浏览组合：** 能绕过崩溃，但改变了原生交互，且原生后端仍然损坏。
+
+## 验证
+
+绑定测试拒绝所有外部视图，覆盖空字符串、ASCII、中文、含空格和代理对的路径。在已安装的 Electron 43.4.1 中运行原生 `CoTaskMemAlloc` 探针，视图实现退出码为 134，复制实现为 0。通过重新构建的安装包进行交互式选择仍需单独验收。
+
+## 后果
+
+每次选择增加一次有界缓冲区分配和内存复制。选择器兼容 Electron 内存笼，无需关闭运行时保护或改变交互协议。

--- a/packages/host/directory-picker-native/README.i18n.yaml
+++ b/packages/host/directory-picker-native/README.i18n.yaml
@@ -2,5 +2,5 @@
 # side as of the last confirmed-consistent state. Both languages carry equal authority;
 # after editing either side, bring the other along and re-record with:
 #   pnpm run verify-translation-pairing --write packages/host/directory-picker-native/README.md
-README.md: 4dd0c79d080fe097d063cfd2200e30aafc2d2d42
-README.zh.md: 36cfe85d22a5c5e598bbda6ffbf8823b44479b8d
+README.md: 5f6bc6a55e2ec06f5ecf3fae5ca9f2f8084db4df
+README.zh.md: 84d005611d1dcd54a13b7623f027a02d69cb69ea

--- a/packages/host/directory-picker-native/README.md
+++ b/packages/host/directory-picker-native/README.md
@@ -6,6 +6,8 @@ The **native-OS-chooser backend** of the [directory-picker seam](../directory-pi
 
 **Dual-face package**: the browser half (`./client`) registers a renderless flow occupant into [ui-workspace's](../../client/ui-workspace/README.md) two directory-flow holes — each `open` request drives `host.pickDirectory` and reports the one outcome (picked path / cancel / failure) through the hole's owner conversation. Both directory-flow declarations must be live before either contribution installs. One cordis.yml row therefore composes both sides of the native interaction; the client carries no capability-kind branching, and mounting a second flow package fails at load (the holes are `single` kind).
 
+Windows selected paths are copied by UTF-16 length into a Node-owned Buffer before decoding, without creating an external ArrayBuffer unsupported by Electron.
+
 ## Model Experience
 
 None, as the backend serves the GUI host's directory selection; nothing here reaches a model request.

--- a/packages/host/directory-picker-native/README.zh.md
+++ b/packages/host/directory-picker-native/README.zh.md
@@ -6,6 +6,8 @@
 
 **双面包**：浏览器端（`./client`）向 [ui-workspace](../../client/ui-workspace/README.zh.md) 的两个目录流 slot 注册一个无渲染的流程占用者——每次 `open` 请求驱动 `host.pickDirectory`，并通过 slot 的属主交互约定上报唯一结果（所选路径／取消／失败）。两个目录流程声明必须同时处于有效状态，任一贡献才会安装。因此一行 cordis.yml 同时组合原生交互的两侧；客户端不包含任何按能力类型进行的分支，挂载第二个流程包会在加载期失败（slot 的 kind 为 `single`）。
 
+Windows 所选路径按 UTF-16 长度复制到 Node 自有的 Buffer，再解码为字符串；不创建 Electron 不支持的外部 ArrayBuffer。
+
 ## 模型体验
 
 无。该后端服务于 GUI 宿主的目录选择；这里没有任何内容进入模型请求。

--- a/packages/host/directory-picker-native/src/win32-dialog-bindings.ts
+++ b/packages/host/directory-picker-native/src/win32-dialog-bindings.ts
@@ -25,27 +25,18 @@ interface Koffi {
   register(fn: (...args: unknown[]) => unknown, type: unknown): unknown
   unregister(callback: unknown): void
   sizeof(type: string): number
-  view(ref: unknown, len: number): ArrayBuffer
 }
 
 /**
- * Read a UTF-16 string at a native address, sized by `lstrlenW` rather than
- * a fixed view. `GetDisplayName`'s result is a `CoTaskMemAlloc`'d buffer
- * exactly `(length + 1) * 2` bytes long — `length` UTF-16 code units plus
- * the terminating NUL — so viewing more than that reads unallocated memory;
- * when the allocation sits near the end of a committed page this faults the
- * process instead of returning garbage
- * (https://github.com/SuperJJ007/papermachine/issues/5). `lstrlenW` reports
- * `length` excluding the NUL, so `(length + 1) * 2` covers exactly the
- * allocation, terminator included; an empty string (`length === 0`) views
- * the 2-byte NUL-only allocation and decodes to `''` with no special case.
- * koffi's `_Out_ void **` out-params surface a raw address, and
- * `koffi.decode(addr, 'str16')` would dereference it as a pointer — crash
- * on real Windows — so view the exact-length memory directly instead.
+ * Copy the COM UTF-16 allocation into a Node-owned buffer before decoding.
+ * Electron's V8 memory cage rejects the external ArrayBuffer created by
+ * koffi.view(), even when its length matches the native allocation.
+ * lstrlenW excludes the NUL; copying it keeps empty strings valid too.
  */
-function readUtf16(koffi: Koffi, lstrlenW: KoffiFunction, address: unknown): string {
+function readUtf16(copyMemory: KoffiFunction, lstrlenW: KoffiFunction, address: unknown): string {
   const length = lstrlenW(address) as number
-  const bytes = Buffer.from(koffi.view(address, (length + 1) * 2))
+  const bytes = Buffer.alloc((length + 1) * 2)
+  copyMemory(bytes, address, bytes.length)
   return bytes.toString('utf16le', 0, length * 2)
 }
 
@@ -107,6 +98,7 @@ export async function loadWin32DialogBindings(): Promise<Win32DialogBindings> {
   const coCreateInstance = ole32.func('__stdcall', 'CoCreateInstance', 'int32', ['void *', 'void *', 'uint32', 'void *', 'void *'])
   const coTaskMemFree = ole32.func('__stdcall', 'CoTaskMemFree', 'void', ['void *'])
   const lstrlenW = kernel32.func('__stdcall', 'lstrlenW', 'int', ['void *'])
+  const copyMemory = kernel32.func('__stdcall', 'RtlMoveMemory', 'void', ['void *', 'void *', 'size_t'])
   const getCurrentThreadId = kernel32.func('__stdcall', 'GetCurrentThreadId', 'uint32', [])
 
   const protoShow = koffi.proto('int32 __stdcall DshDialogShow(void *self, void *owner)')
@@ -165,7 +157,7 @@ export async function loadWin32DialogBindings(): Promise<Win32DialogBindings> {
             const nameOut: unknown[] = [null]
             const gotName = method(item, SLOT_GET_DISPLAY_NAME, protoGetDisplayName)(SIGDN_FILESYSPATH, nameOut)
             if (gotName < 0) return { hr: gotName }
-            const path = readUtf16(koffi, lstrlenW, nameOut[0])
+            const path = readUtf16(copyMemory, lstrlenW, nameOut[0])
             coTaskMemFree(nameOut[0])
             return { hr: gotName, path }
           } finally {

--- a/packages/host/directory-picker-native/tests/win32-dialog-bindings.spec.ts
+++ b/packages/host/directory-picker-native/tests/win32-dialog-bindings.spec.ts
@@ -106,6 +106,12 @@ function installFakeKoffi(world: ComWorld): void {
             }
             case 'CoTaskMemFree': return (ptr: unknown) => { world.freed.push(ptr) }
             case 'lstrlenW': return (ptr: unknown) => ((ptr as FakePtr).text as string).length
+            case 'RtlMoveMemory': return (target: Buffer, source: FakePtr, len: number) => {
+              const bytes = Buffer.from((source.text as string) + '\0', 'utf16le')
+              expect(len).toBe(bytes.length)
+              expect(target.length).toBe(len)
+              bytes.copy(target)
+            }
             case 'GetCurrentThreadId': return () => 31337
             case 'SetThreadDpiAwarenessContext': {
               if (!world.hasThreadDpi) throw new Error(`${dll}: SetThreadDpiAwarenessContext not found`)
@@ -128,19 +134,7 @@ function installFakeKoffi(world: ComWorld): void {
       proto: (declaration: string) => ({ declaration }),
       pointer: (type: unknown) => type,
       sizeof: (type: string) => { void type; return FAKE_POINTER_SIZE },
-      view: (value: unknown, len: number): ArrayBuffer => {
-        // Models the real CoTaskMemAlloc'd buffer: exactly (text.length + 1)
-        // UTF-16 code units (the terminating NUL included). A view past that
-        // reads unallocated memory — a real page-boundary fault when the
-        // allocation sits at the end of a committed page — so the fake
-        // throws instead of silently returning it.
-        const text = (value as FakePtr).text as string
-        const allocatedBytes = (text.length + 1) * 2
-        if (len > allocatedBytes) throw new Error(`view(${len}) exceeds the ${allocatedBytes}-byte allocation`)
-        const bytes = Buffer.alloc(len)
-        bytes.write(text, 'utf16le')
-        return bytes.buffer
-      },
+      view: () => { throw new Error('Electron rejects external ArrayBuffers') },
       register: (fn: (hwnd: unknown, lparam: unknown) => number) => { world.registered += 1; return { fn } },
       unregister: () => { world.unregistered += 1 },
       decode: (value: unknown, offsetOrType: unknown): unknown => {
@@ -192,8 +186,9 @@ describe('loadWin32DialogBindings over the fake COM world', () => {
   it.each([
     ['an ASCII path', 'C:\\Users\\alex\\Documents'],
     ['a path with spaces and CJK characters', 'D:\\研究 数据\\项目'],
+    ['a path with surrogate pairs', 'D:\\研究 数据\\项目😀'],
     ['an empty path', ''],
-  ])('reads %s by its exact lstrlenW length, not a fixed-size view', async (_label, path) => {
+  ])('copies %s without an external ArrayBuffer', async (_label, path) => {
     const world = comWorld({ path })
     installFakeKoffi(world)
     const { loadWin32DialogBindings } = await loadBindingsModule()


### PR DESCRIPTION
处理结果：此补丁已由合并的 #32 中的新基线实现替代，因此关闭为 superseded，未叠加合并旧实现。

当前 `main` 的 `readUtf16` 将地址写入指针宽度的 Buffer，再调用 `koffi.decode(buffer, 'str16')`，不再使用 `koffi.view` 或创建外部 ArrayBuffer。对应真实 Koffi 测试覆盖中文、代理对、NUL 终止、长路径和指针宽度；候选 `f9ad4ac9ad` 的完整 Linux/Windows CI 均通过。实现决策见 `.agents/notes/implemented/bug-fix/2026-08-31-win32-picker-path-string-read.md`。交互式安装器验收仍是单独的验证项。

---

关联 Issue：Related to #5

PaperMachine 0.1.1 在 Windows 中确认文件夹后，原生 worker 仍在 `readUtf16` 中以 `FATAL ERROR: Error::New napi_get_last_error_info` 崩溃。发布版已使用 `lstrlenW` 限定长度；剩余问题是 `koffi.view` 创建的外部 ArrayBuffer 与 Electron 的 V8 内存笼不兼容，缩小视图长度无法解决。

本补丁使用 `RtlMoveMemory` 将 COM 字符串按精确长度复制到 Node 自有 Buffer，再解码 UTF-16；不改变原生对话框、取消协议或 COM 清理流程。回归测试将所有 `koffi.view` 调用设为失败，覆盖空字符串、英文、中文、空格和代理对路径。中英文 README 与设计记录同步更新。

依据：[Electron 官方关于 V8 memory cage 的说明](https://www.electronjs.org/blog/v8-memory-cage)。

验证：

- Windows x64，已安装的 PaperMachine 0.1.1 / Electron 43.4.1 / Koffi 3.1.1：以 `CoTaskMemAlloc` 创建合法原生 UTF-16 字符串，原 view 实现退出码 134；复制方案退出码 0。
- 将本 PR 的实际 TypeScript 路径读取函数转译后放入相同 Electron 进程执行，空字符串、英文和中文/emoji 路径均通过，退出码 0。
- `pnpm exec vitest run packages/host/directory-picker-native/tests/win32-dialog-bindings.spec.ts --coverage --coverage.include=packages/host/directory-picker-native/src/win32-dialog-bindings.ts`：16 项通过，目标文件语句、分支、函数和行覆盖率均为 100%。
- `pnpm run doc-sync`：28/29 项通过；唯一失败是未改动的 `scripts/project-doc-site.spec.ts:87` 创建 Windows 文件符号链接被拒绝（`EPERM`），尚未进入受测函数。未关闭检查或修改系统权限。
- README 英文增加 22 个空白分隔词，中文增加一段对应说明，无文档预算例外。
- `built-worker.e2e.ts` 按既有配置在 Windows 跳过，未将跳过计为通过。
- `pnpm run lint`（包含 Host TypeScript 构建和原生 worker 打包）通过；提交钩子的 staged lint、双语记录、空白和 vendor 检查通过。
- 推送钩子的 `pnpm run typecheck` 通过，未跳过 Git 钩子。

这是 Draft：尚未通过重新打包的安装器验收完整交互式选目录流程。贡献说明目前写着暂不接受外部 PR；按报告者要求提供这个小补丁，供维护者审阅或自行 cherry-pick。
