### PR TITLE
feat(environments): add biomedical scientific environment declaration

### DIFF
--- a/apps/desktop/resources/environments/biomedical.json
+++ b/apps/desktop/resources/environments/biomedical.json
@@ -1,0 +1,48 @@
+{
+  "schemaVersion": 1,
+  "id": "biomedical",
+  "revision": "2026.09.2",
+  "name": "生物医学环境 · Biomedical statistics",
+  "supportedPlatforms": ["darwin-arm64", "darwin-x64", "win32-x64"],
+  "sources": [
+    {
+      "id": "ustc",
+      "name": "中科大 USTC 镜像 · USTC mirror",
+      "channels": ["https://mirrors.ustc.edu.cn/anaconda/cloud/conda-forge"]
+    },
+    {
+      "id": "tuna",
+      "name": "清华 TUNA 镜像 · TUNA mirror",
+      "channels": ["https://mirrors.tuna.tsinghua.edu.cn/anaconda/cloud/conda-forge"]
+    },
+    {
+      "id": "official",
+      "name": "官方源 · Official channel",
+      "channels": ["https://conda.anaconda.org/conda-forge"]
+    }
+  ],
+  "packages": [
+    "python=3.13", "numpy=2.3", "scipy=1.16", "pandas=2.3", "matplotlib=3.10", "seaborn=0.13",
+    "statsmodels=0.14", "scikit-learn=1.7", "pyarrow=21", "openpyxl=3.1", "pyreadstat=1.3", "pillow=11",
+    "lifelines", "scikit-survival", "pingouin", "tableone", "tabulate", "forestplot", "pydicom", "nibabel",
+    "r-base=4.5", "r-tidyverse=2.0", "r-haven=2.5", "r-broom=1.0", "r-lme4", "r-data.table=1.18", "r-jsonlite=2.0",
+    "r-survival", "r-survminer", "r-cmprsk", "r-tidycmprsk", "r-ggsurvfit", "r-riskregression", "r-mmrm", "r-rms",
+    "r-meta", "r-metafor", "r-tableone", "r-gtsummary", "r-matchit", "r-weightit", "r-cobalt", "r-marginaleffects",
+    "r-proc", "r-epir", "r-dcurves", "r-emmeans", "r-mice", "r-pmsampsize"
+  ],
+  "estimatedDownloadBytes": 900000000,
+  "requiredFreeBytes": 9000000000,
+  "timeoutMs": 5400000,
+  "healthChecks": [
+    {
+      "language": "python",
+      "executable": "python",
+      "args": ["-c", "import numpy,scipy,pandas,matplotlib,statsmodels,sklearn,lifelines,sksurv,pingouin,tableone,tabulate,pydicom"]
+    },
+    {
+      "language": "r",
+      "executable": "Rscript",
+      "args": ["-e", "library(tidyverse);library(survival);library(survminer);library(cmprsk);library(tidycmprsk);library(ggsurvfit);library(riskRegression);library(mmrm);library(meta);library(metafor);library(MatchIt);library(marginaleffects);library(rms);library(pROC);library(mice);library(pmsampsize)"]
+    }
+  ]
+}

--- a/apps/desktop/resources/onboarding.html
+++ b/apps/desktop/resources/onboarding.html
@@ -23,7 +23,8 @@
   </section>
 
   <section id="install" class="group">
-    <h2>安装标准环境 · Install the standard environment</h2>
+    <h2>安装科学环境 · Install a science environment</h2>
+    <div id="offered-environments" class="choices" style="margin-bottom: 14px" hidden></div>
     <div class="actions">
       <span>安装位置 · Install location: <code id="install-location-path"></code></span>
       <button id="change-install-location" class="secondary">更改… · Change…</button>

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -157,13 +157,23 @@ async function desktopHostConfig(): Promise<DesktopHostConfig> {
   return parseDesktopHostConfig(JSON.parse(await readFile(join(resourceRoot(), 'host.json'), 'utf8')))
 }
 
-/** The one environment this build ships; disciplines are added as further declarations. */
-const SHIPPED_ENVIRONMENT_ID = 'general'
+/** The environments this build ships; disciplines are added as further declarations. */
+const SHIPPED_ENVIRONMENT_IDS = ['general', 'biomedical'] as const
+
+async function shippedDeclarations(): Promise<readonly EnvironmentDeclaration[]> {
+  return Promise.all(
+    SHIPPED_ENVIRONMENT_IDS.map(async id =>
+      parseEnvironmentDeclaration(
+        JSON.parse(await readFile(join(resourceRoot(), 'environments', `${id}.json`), 'utf8')),
+      ),
+    ),
+  )
+}
 
 /** Read the shipped declaration; the standard package set onboarding offers and the custom editor starts from. */
 async function shippedDeclaration(): Promise<EnvironmentDeclaration> {
   return parseEnvironmentDeclaration(
-    JSON.parse(await readFile(join(resourceRoot(), 'environments', `${SHIPPED_ENVIRONMENT_ID}.json`), 'utf8')),
+    JSON.parse(await readFile(join(resourceRoot(), 'environments', 'general.json'), 'utf8')),
   )
 }
 
@@ -176,7 +186,8 @@ async function shippedDeclaration(): Promise<EnvironmentDeclaration> {
  */
 async function declarations(dshHome: string): Promise<readonly EnvironmentDeclaration[]> {
   const custom = await readCustomDeclaration(desktopEnvironmentsRoot(dshHome))
-  return [await shippedDeclaration(), ...(custom === undefined ? [] : [custom])]
+  const shipped = await shippedDeclarations()
+  return [...shipped, ...(custom === undefined ? [] : [custom])]
 }
 
 /** The bundled micromamba executable for this machine, shared by provisioning and the Host's package installer. */
@@ -265,7 +276,7 @@ async function startProvisioning(dshHome: string, declaration: EnvironmentDeclar
         event: 'environment.installed',
         sourceId: published.sourceId,
         durationMs: Date.now() - startedAt,
-        environmentId: declaration.id === CUSTOM_ENVIRONMENT_ID ? 'custom' : 'general',
+        environmentId: declaration.id === CUSTOM_ENVIRONMENT_ID ? 'custom' : declaration.id === 'biomedical' ? 'biomedical' : 'general',
       })
       await openWorkspace()
     } catch (error) {
@@ -285,12 +296,9 @@ async function startProvisioning(dshHome: string, declaration: EnvironmentDeclar
 }
 
 /**
- * Write the Host overlay for `binding`. The install channels are the shipped
- * declaration's sources reordered to start from the bound source, flattened
- * to their channel URLs, so a package install first tries the mirror the
- * environment itself came from; a bound source id the shipped declaration no
- * longer lists (a later build renamed its sources) keeps the declaration's
- * own order, the same rule `orderSourcesFrom` applies to provisioning's
+ * Write the Science Runtime overlay file the Host is launched with.
+ * The overlay pins micromamba, the interpreters, and the channels of the
+ * applied declaration (falling back to shipped general) ordered from the
  * preferred source. A custom package set shares the shipped sources
  * unchanged (`buildCustomDeclaration`), so the shipped declaration is the
  * one source list for both.
@@ -300,7 +308,9 @@ async function startProvisioning(dshHome: string, declaration: EnvironmentDeclar
  */
 async function writeRuntimeOverlay(dshHome: string, binding: EnvironmentBinding): Promise<string> {
   const overlay = join(dshHome, 'desktop-science.cordis.patch.yml')
-  const sources = orderSourcesFrom((await shippedDeclaration()).sources, binding.sourceId)
+  const decls = await declarations(dshHome)
+  const appliedDecl = decls.find(d => d.id === binding.id) ?? await shippedDeclaration()
+  const sources = orderSourcesFrom(appliedDecl.sources, binding.sourceId)
   await writeFile(overlay, renderDesktopRuntimeOverlay({
     ...(binding.pythonPrefix === undefined ? {} : { pythonPrefix: binding.pythonPrefix }),
     ...(binding.rPrefix === undefined ? {} : { rPrefix: binding.rPrefix }),

--- a/apps/desktop/src/onboarding.ts
+++ b/apps/desktop/src/onboarding.ts
@@ -228,6 +228,36 @@ function dismissConfirm(): void {
   confirm.hidden = true
 }
 
+const offeredEnvironmentsElement = document.querySelector('#offered-environments')
+const offeredEnvironments = offeredEnvironmentsElement instanceof HTMLDivElement ? offeredEnvironmentsElement : undefined
+
+function renderOfferedEnvironments(
+  environments: readonly OfferedEnvironment[],
+  selectedId: string | undefined,
+  onSelect: (env: OfferedEnvironment) => void,
+): void {
+  if (!offeredEnvironments) return
+  offeredEnvironments.replaceChildren()
+  for (const env of environments) {
+    const label = document.createElement('label')
+    label.className = 'choice'
+    const input = document.createElement('input')
+    input.type = 'radio'
+    input.name = 'discipline-environment'
+    input.value = env.id
+    input.checked = env.id === selectedId
+    input.addEventListener('change', () => { onSelect(env) })
+    const copy = document.createElement('span')
+    const strong = document.createElement('strong')
+    strong.textContent = env.name
+    const small = document.createElement('small')
+    small.textContent = `${String(env.packages.length)} 个包 · 约 ${formatBytes(env.estimatedDownloadBytes)} · ${String(env.packages.length)} packages, ~${formatBytes(env.estimatedDownloadBytes)}`
+    copy.append(strong, small)
+    label.append(input, copy)
+    offeredEnvironments.append(label)
+  }
+}
+
 /** Render the resolved Harness home path and show "Use default" only while a pointer file is in effect. */
 async function loadInstallLocation(): Promise<void> {
   try {
@@ -253,10 +283,16 @@ async function loadEnvironments(): Promise<void> {
       window.desktopOnboarding.environments(),
       window.desktopOnboarding.currentEnvironment(),
     ])
-    const shipped = offered[0]
-    if (shipped === undefined) throw new Error(ENVIRONMENTS_UNAVAILABLE_MESSAGE)
+    const initial = offered[0]
+    if (initial === undefined) throw new Error(ENVIRONMENTS_UNAVAILABLE_MESSAGE)
     if (applied !== undefined) renderCurrent(applied)
-    renderStandard(shipped)
+    if (offered.length > 1 && offeredEnvironments) {
+      renderOfferedEnvironments(offered, initial.id, (selected) => {
+        renderStandard(selected)
+      })
+      offeredEnvironments.hidden = false
+    }
+    renderStandard(initial)
     provision.disabled = false
   } catch (error) {
     installSummary.textContent = bridgeErrorMessage(error)

--- a/apps/desktop/src/telemetry.ts
+++ b/apps/desktop/src/telemetry.ts
@@ -40,7 +40,7 @@ export type TelemetryEventInput =
     /** The package source that succeeded (`tuna`/`ustc`/`official`, or a custom declaration's chosen source id). */
     readonly sourceId: string
     readonly durationMs: number
-    readonly environmentId: 'general' | 'custom'
+    readonly environmentId: 'general' | 'biomedical' | 'custom'
   }
   | {
     readonly event: 'environment.install-failed'

--- a/apps/desktop/tests/environment-declaration.spec.ts
+++ b/apps/desktop/tests/environment-declaration.spec.ts
@@ -34,6 +34,13 @@ describe('desktop environment declarations', () => {
     expect(parsed.healthChecks.map(check => check.language)).toEqual(['python', 'r'])
   })
 
+  it('accepts the shipped biomedical declaration', async () => {
+    const parsed = parseEnvironmentDeclaration(JSON.parse(await readFile(join(resources, 'biomedical.json'), 'utf8')))
+    expect(parsed.id).toBe('biomedical')
+    expect(parsed.name).toContain('生物医学')
+    expect(parsed.healthChecks.map(check => check.language)).toEqual(['python', 'r'])
+  })
+
   // USTC, not TUNA, is first: TUNA's longer mirror hostname pushes this
   // declaration's deepest transitive dependency 1 character past win32's
   // `MAX_PATH` under the shipped package cache root, confirmed on real

--- a/apps/desktop/tests/onboarding.spec.ts
+++ b/apps/desktop/tests/onboarding.spec.ts
@@ -45,6 +45,7 @@ function setDom(): void {
       <button id="keep-current"></button>
     </section>
     <section id="install">
+      <div id="offered-environments" class="choices" style="margin-bottom: 14px" hidden></div>
       <div class="actions">
         <span>Install location: <code id="install-location-path"></code></span>
         <button id="change-install-location"></button>
@@ -605,5 +606,36 @@ describe('install location', () => {
     await vi.waitFor(() => { expect(writeText).toHaveBeenCalledTimes(1) })
     const report = writeText.mock.calls[0]?.[0] ?? ''
     expect(report).not.toContain('Full log files')
+  })
+
+  it('renders a radio group when multiple environments are offered and updates selection on change', async () => {
+    const BIOMEDICAL: OfferedEnvironment = {
+      id: 'biomedical',
+      name: 'Biomedical statistics',
+      revision: '2026.09.2',
+      packages: ['python=3.13', 'r-base=4.5', 'lifelines'],
+      estimatedDownloadBytes: 900_000_000,
+      requiredFreeBytes: 9_000_000_000,
+      sources: [{ id: 'tuna', name: 'TUNA mirror' }],
+      defaultSourceId: 'tuna',
+    }
+    const { bridge } = installBridge({ environments: vi.fn(async () => [STANDARD, BIOMEDICAL]) })
+    await loadOnboarding(bridge)
+
+    const offeredContainer = requireElement('#offered-environments') as HTMLDivElement
+    expect(offeredContainer.hidden).toBe(false)
+    const radios = offeredContainer.querySelectorAll<HTMLInputElement>('input[type="radio"]')
+    expect(radios.length).toBe(2)
+    expect(radios[0]?.value).toBe('general')
+    expect(radios[0]?.checked).toBe(true)
+    expect(radios[1]?.value).toBe('biomedical')
+    expect(radios[1]?.checked).toBe(false)
+
+    radios[1]!.checked = true
+    radios[1]!.dispatchEvent(new Event('change', { bubbles: true }))
+
+    const summary = requireElement('#install-summary')
+    expect(summary.textContent).toContain('Biomedical statistics')
+    expect(summary.textContent).toContain('3 packages')
   })
 })


### PR DESCRIPTION
## feat(environments): add biomedical scientific environment declaration

Part of RFC #28 (Modular Biomedical Research Extension).

### Overview

This PR introduces the **Biomedical statistics discipline environment** declaration to PaperMachine Desktop as a completely optional, user-selectable environment alongside `general`.

### What this PR adds

1. **Environment Declaration** (`apps/desktop/resources/environments/biomedical.json`):
   - Pure `conda-forge` channels supporting `darwin-arm64`, `darwin-x64`, and `win32-x64`.
   - Packages:
     - Python: `lifelines`, `scikit-survival`, `pingouin`, `tableone`, `tabulate`, `forestplot`, `pydicom`, `nibabel`, etc.
     - R: `r-survival`, `r-survminer`, `r-cmprsk`, `r-tidycmprsk`, `r-ggsurvfit`, `r-riskregression`, `r-mmrm`, `r-rms`, `r-meta`, `r-metafor`, `r-tableone`, `r-gtsummary`, `r-matchit`, `r-weightit`, `r-cobalt`, `r-marginaleffects`, `r-proc`, `r-epir`, `r-dcurves`, `r-emmeans`, `r-mice`, `r-pmsampsize`.
   - Ordered mirror sources (`ustc`, `tuna`, `official`) matching Windows MAX_PATH safety standards.
2. **Desktop Wiring & Selection** (`apps/desktop/src/main.ts`, `onboarding.ts`, `onboarding.html`):
   - `SHIPPED_ENVIRONMENT_IDS = ['general', 'biomedical']`
   - Multi-environment radio group rendered in onboarding UI when multiple disciplines are offered, with `general` pre-selected by default.
   - `writeRuntimeOverlay` resolves mirror channels dynamically from the applied environment declaration.
   - Telemetry `environmentId` widened to include `'biomedical'`.
3. **Automated Unit Tests**:
   - `apps/desktop/tests/environment-declaration.spec.ts`: verified `biomedical.json` parses and passes schema and health check requirements.
   - `apps/desktop/tests/onboarding.spec.ts`: verified multi-discipline radio selection and UI summary updates.

### Backward Compatibility

- General Science (`general`) remains the default out-of-the-box experience.
- Existing custom environments and configurations remain completely unaffected.
